### PR TITLE
Ignore Methods declared on any trait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 php:
   - 7.1
-  - 7.2
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "php": "^7.1",
         "illuminate/console": "^5.5",
         "illuminate/support": "^5.5",
         "symfony/finder": "^3.3"

--- a/src/Analyzers/ClassMethodsAnalyzer.php
+++ b/src/Analyzers/ClassMethodsAnalyzer.php
@@ -78,9 +78,9 @@ class ClassMethodsAnalyzer
 
     /**
      * Return a Collection of Method Names which are only declared on the class itself
-     * Methods declared on a used trait are beeing ignored
+     * Methods declared on a used trait are beeing ignored.
      *
-     * @param  ReflectionClass $class
+     * @param ReflectionClass $class
      *
      * @return Collection
      */
@@ -92,7 +92,8 @@ class ClassMethodsAnalyzer
     }
 
     /**
-     * Get an Array of Trait Methods
+     * Get an Array of Trait Methods.
+     *
      * @return array
      */
     protected function getTraitMethods($class) : array
@@ -100,13 +101,12 @@ class ClassMethodsAnalyzer
         $methods = [];
         $traits = $class->getTraits();
 
-        foreach($traits as $trait) {
-            foreach($trait->getMethods() as $method) {
+        foreach ($traits as $trait) {
+            foreach ($trait->getMethods() as $method) {
                 $methods[] = $method->getName();
             }
         }
 
         return $methods;
     }
-
 }

--- a/src/Analyzers/ClassMethodsAnalyzer.php
+++ b/src/Analyzers/ClassMethodsAnalyzer.php
@@ -17,7 +17,7 @@ class ClassMethodsAnalyzer
      */
     public function getNumberOfMethods(ReflectionClass $class) : int
     {
-        return $this->getMethods($class)->collapse()->count();
+        return $this->getMethodsWithoutTraitMethods($class)->count();
     }
 
     /**
@@ -29,7 +29,7 @@ class ClassMethodsAnalyzer
      */
     public function getCollectionOfMethodNames(ReflectionClass $class) : Collection
     {
-        return $this->getMethods($class);
+        return $this->getMethodsWithoutTraitMethods($class);
     }
 
     /**
@@ -71,6 +71,42 @@ class ClassMethodsAnalyzer
             }
         }
 
-        return collect($return);
+        $return = collect($return)->collapse();
+
+        return $return;
     }
+
+    /**
+     * Return a Collection of Method Names which are only declared on the class itself
+     * Methods declared on a used trait are beeing ignored
+     *
+     * @param  ReflectionClass $class
+     *
+     * @return Collection
+     */
+    public function getMethodsWithoutTraitMethods(ReflectionClass $class) : Collection
+    {
+        return $this->getMethods($class)->diff(
+            collect($this->getTraitMethods($class))
+        );
+    }
+
+    /**
+     * Get an Array of Trait Methods
+     * @return array
+     */
+    protected function getTraitMethods($class) : array
+    {
+        $methods = [];
+        $traits = $class->getTraits();
+
+        foreach($traits as $trait) {
+            foreach($trait->getMethods() as $method) {
+                $methods[] = $method->getName();
+            }
+        }
+
+        return $methods;
+    }
+
 }

--- a/tests/Analyzers/ClassMethodsAnalyzerTest.php
+++ b/tests/Analyzers/ClassMethodsAnalyzerTest.php
@@ -4,6 +4,7 @@ namespace Wnx\LaravelStats\Tests\Analyzers;
 
 use ReflectionClass;
 use Wnx\LaravelStats\Analyzers\ClassMethodsAnalyzer;
+use Wnx\LaravelStats\Tests\Stubs\Controllers\Controller;
 use Wnx\LaravelStats\Tests\Stubs\Controllers\ProjectsController;
 use Wnx\LaravelStats\Tests\TestCase;
 
@@ -17,18 +18,9 @@ class ClassMethodsAnalyzerTest extends TestCase
 
         $methodsCollection = $service->getCollectionOfMethodNames($reflection);
 
-        $this->assertArrayHasKey('public', $methodsCollection);
-        $this->assertArrayHasKey('protected', $methodsCollection);
-        $this->assertArrayHasKey('private', $methodsCollection);
-
-        $this->assertArraySubset(
-            ['index', 'show'],
-            $methodsCollection->toArray()['public']
-        );
-        $this->assertArraySubset(
-            ['protectedControllerMethod'],
-            $methodsCollection->toArray()['protected']
-        );
+        $this->assertContains('index', $methodsCollection->toArray());
+        $this->assertContains('show', $methodsCollection->toArray());
+        $this->assertContains('protectedControllerMethod', $methodsCollection->toArray());
     }
 
     /** @test */
@@ -40,5 +32,16 @@ class ClassMethodsAnalyzerTest extends TestCase
         $numberOfMethods = $service->getNumberOfMethods($reflection);
 
         $this->assertEquals(3, $numberOfMethods);
+    }
+
+    /** @test */
+    public function it_ignores_method_declared_on_traits()
+    {
+        $service = resolve(ClassMethodsAnalyzer::class);
+        $reflection = new ReflectionClass(Controller::class);
+
+        $numberOfMethods = $service->getNumberOfMethods($reflection);
+
+        $this->assertEquals(0, $numberOfMethods);
     }
 }


### PR DESCRIPTION
This PR adds a new `getMethodsWithoutTraitMethods`  on the `ClassMethodsAnalyzer` class. 

The new method will first collect all method names declared on all the traits used by the class and will then return the diff between the previously collected method names and the trait-method names.