### PR TITLE
Don't count native and vendor classes

### DIFF
--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -48,7 +48,7 @@ class ClassFinder
         })->reject(function ($class) {
             return (new ReflectionClass($class))->isNative();
         })->reject(function ($class) {
-            return (new ReflectionClass($class))->isVendorProvided($this->basePath);
+            return (new ReflectionClass($class))->isVendorProvided();
         });
 
         return $filtered;

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -45,6 +45,8 @@ class ClassFinder
             return starts_with($value, 'Illuminate'); // Ignore Illuminate Packages
         })->reject(function ($value, $key) {
             return starts_with($value, 'Symfony');
+        })->reject(function ($class) {
+            return (new ReflectionClass($class))->isNative();
         });
 
         return $filtered;

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -47,6 +47,8 @@ class ClassFinder
             return starts_with($value, 'Symfony');
         })->reject(function ($class) {
             return (new ReflectionClass($class))->isNative();
+        })->reject(function ($class) {
+            return (new ReflectionClass($class))->isVendorProvided($this->basePath);
         });
 
         return $filtered;

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -25,7 +25,7 @@ class ReflectionClass
     public function isVendorProvided($root)
     {
         return $this->class->getFileName()
-            && str_contains($this->class->getFileName(), "/vendor/");
+            && str_contains($this->class->getFileName(), '/vendor/');
     }
 
     public function getLaravelComponentName()

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -22,6 +22,12 @@ class ReflectionClass
         return $this->class->getFileName() === false;
     }
 
+    public function isVendorProvided($root)
+    {
+        return $this->class->getFileName()
+            && str_contains($this->class->getFileName(), "/vendor/");
+    }
+
     public function getLaravelComponentName()
     {
         if ($componentName = $this->extendsLaravelComponentClass($this->class)) {

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -22,7 +22,7 @@ class ReflectionClass
         return $this->class->getFileName() === false;
     }
 
-    public function isVendorProvided($root)
+    public function isVendorProvided()
     {
         return $this->class->getFileName()
             && str_contains($this->class->getFileName(), '/vendor/');

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -17,6 +17,11 @@ class ReflectionClass
         $this->class = new NativeReflectionClass($className);
     }
 
+    public function isNative()
+    {
+        return $this->class->getFileName() === false;
+    }
+
     public function getLaravelComponentName()
     {
         if ($componentName = $this->extendsLaravelComponentClass($this->class)) {

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -159,7 +159,6 @@ class ClassFinderTest extends TestCase
     {
         $classes = $this->getFinder()->getDeclaredClasses();
 
-        $this->assertFalse($classes->contains(\PHPUnit\Framework\TestCase::class));
-        $this->assertFalse($classes->contains(\Orchestra\Testbench\TestCase::class));
+        $this->assertFalse($classes->contains(\Symfony\Component\Finder\Finder::class));
     }
 }

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -144,4 +144,13 @@ class ClassFinderTest extends TestCase
         $this->assertFalse($classes->contains('blade'));
         $this->assertFalse($classes->contains('twig'));
     }
+
+    /** @test */
+    public function it_ignores_native_php_classes()
+    {
+        $classes = $this->getFinder()->getDeclaredClasses();
+
+        $this->assertFalse($classes->contains('stdClass'));
+        $this->assertFalse($classes->contains('Exception'));
+    }
 }

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -153,4 +153,13 @@ class ClassFinderTest extends TestCase
         $this->assertFalse($classes->contains('stdClass'));
         $this->assertFalse($classes->contains('Exception'));
     }
+
+    /** @test */
+    public function it_ignores_vendored_classes()
+    {
+        $classes = $this->getFinder()->getDeclaredClasses();
+
+        $this->assertFalse($classes->contains(\PHPUnit\Framework\TestCase::class));
+        $this->assertFalse($classes->contains(\Orchestra\Testbench\TestCase::class));
+    }
 }


### PR DESCRIPTION
This is an initial PR to look at the best way to ignore native (PHP provided) classes as well as vendor provided classes.