### PR TITLE
Reduce Laravel Requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/console": "^5.5",
-        "illuminate/support": "^5.5",
+        "illuminate/console": "~5.2|~5.3|~5.4|~5.5",
+        "illuminate/support": "~5.2|~5.3|~5.4|~5.5",
         "phploc/phploc": "^4.0",
         "symfony/finder": "^3.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.5",
+        "orchestra/testbench": "~3.2|~3.3|~3.4|~3.5",
         "php-coveralls/php-coveralls": "^1.0",
-        "phpunit/phpunit": "6.*"
+        "phpunit/phpunit": "~5.7|~6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR tries to reduce the Laravel Requirements from 5.5 to support from version 5.2 up 5.5.
(If adding support for lower versions is too much work and just adds a lot of workaround-code it won't be implemented)

#### Related Issues

- #23 