### PR TITLE
Suggestion: Remove coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 composer.phar
 composer.lock
 vendor
-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ php:
   - 7.1
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction
 
 script: phpunit
-
-after_success:
-  - travis_retry php vendor/bin/coveralls

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 <a href="https://travis-ci.org/stefanzweifel/laravel-stats">
     <img src="https://travis-ci.org/stefanzweifel/laravel-stats.svg" alt="">
 </a>
-<a href="https://coveralls.io/github/stefanzweifel/laravel-stats?branch=master">
-    <img src="https://coveralls.io/repos/github/stefanzweifel/laravel-stats/badge.svg?branch=master" alt="">
-</a>
 <a href="https://packagist.org/packages/wnx/laravel-stats">
     <img src="https://poser.pugx.org/wnx/laravel-stats/v/stable" alt="">
 </a>

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     },
     "require-dev": {
         "orchestra/testbench": "^3.5",
-        "php-coveralls/php-coveralls": "^1.0",
         "phpunit/phpunit": "6.*"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,11 +22,4 @@
             <directory suffix=".php">test/Stubs/</directory>
       </exclude>
     </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
This might seem controversial at first but hear me out:

1. It produces incorrect feedback (https://github.com/stefanzweifel/laravel-stats/pull/31#issuecomment-336170248)
2. **It's SLOW**. It takes up to 40 seconds to run tests on Travis when generating code coverage, compared to 300ms (on my machine)
3. It has outdated dependencies, causing composer to complain: `guzzle/guzzle`
4. Code coverage can still be generated locally by running: `phpunit --coverage-html=./coverage` (I'd suggest creating a composer script for this)
5. Code coverage is a nice metrics to find out what parts of the project need more focus. However, this does not need to be checked/generated every time there is a change. Code coverage doesn't tell you wether your system works. It only points out sections of the system that _might_ need more attention.

Overall, not including `coveralls` would improve the contribution experience .