### PR TITLE
Refactor config (base_path and ignores)

### DIFF
--- a/config/stats.php
+++ b/config/stats.php
@@ -2,8 +2,19 @@
 
 return [
 
-    'path' => [
+    /**
+     * List of folders to be analyzed.
+     */
+    'paths' => [
         base_path('app'),
+    ],
+
+    /**
+     * List of files/folders to be excluded from analysis.
+     */
+    'exclude' => [
+        // base_path('app/helpers.php'),
+        // base_path('app/Services'),
     ],
 
 ];

--- a/config/stats.php
+++ b/config/stats.php
@@ -2,28 +2,8 @@
 
 return [
 
-    /*
-     * Every project is different and sometimes files
-     * and folders should be ignored and never
-     * count towards the project stats.
-     */
-    'ignore' => [
-
-        /*
-         * Ignore the contents of an entire folder
-         */
-        'folders' => [
-            // 'app/Http/Controllers'
-        ],
-
-        /*
-         * Ignore certain filenames or extensions
-         */
-        'files' => [
-            // 'helpers.php'
-            // 'twig.php'
-        ],
-
+    'path' => [
+        base_path('app'),
     ],
 
 ];

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -13,17 +13,9 @@ class ClassFinder
      */
     protected $finder;
 
-    /**
-     * @var string
-     */
-    protected $basePath;
-
     public function __construct(Finder $finder)
     {
         $this->finder = $finder;
-
-        // Set default base path to look for classes
-        $this->basePath = base_path();
     }
 
     /**
@@ -42,16 +34,6 @@ class ClassFinder
             ->reject(function ($class) {
                 return (new ReflectionClass($class))->isVendorProvided();
             });
-    }
-
-    /**
-     * Set base path.
-     *
-     * @param string $path
-     */
-    public function setBasePath($path)
-    {
-        $this->basePath = $path;
     }
 
     /**

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -39,34 +39,23 @@ class ClassFinder
 
     /**
      * Find PHP Files on filesystem and require them.
+     * We need to use ob_* functions to ensure that
+     * loaded files do not output anything.
      *
      * @return void
      */
     protected function findAndLoadClasses()
     {
-        $this->requireClassesFromFiles(
-            $this->findFilesInProjectPath()
-        );
+        ob_start();
+
+        $this->findFilesInProjectPath()
+            ->each(function ($file) {
+                require_once $file->getRealPath();
+            });
+
+        ob_end_clean();
 
         return collect(get_declared_classes());
-    }
-
-    /**
-     * Require each PHP file to make them available
-     * in the get_declared_classes function.
-     *
-     * @param Collection $files
-     *
-     * @return void
-     */
-    protected function requireClassesFromFiles(Collection $files)
-    {
-        foreach ($files as $file) {
-            try {
-                require_once $file->getRealPath();
-            } catch (Exception $e) {
-            }
-        }
     }
 
     /**

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -93,61 +93,8 @@ class ClassFinder
      */
     public function findFilesInProjectPath() : Finder
     {
-        $excludedFolders = $this->getFoldersToIgnore();
-
-        $this->finder->files()
-            ->in($this->basePath)
-            ->exclude($excludedFolders)
+        return $this->finder->files()
+            ->in(config('stats.path', []))
             ->name('*.php');
-
-        foreach ($this->getFilesToIgnore() as $filename) {
-            $this->finder->notName($filename);
-        }
-
-        return $this->finder;
-    }
-
-    /**
-     * Get an array of folder paths in which we shouldn't search for files.
-     *
-     * @return array
-     */
-    protected function getFoldersToIgnore() : array
-    {
-        $defaultIgnoredFolders = [
-            'bootstrap',
-            'config',
-            'public',
-            'resources',
-            'routes',
-            'storage',
-            'tests',
-            'vendor',
-        ];
-
-        $customIgnoredFolders = config('stats.ignore.folders');
-
-        return array_merge($defaultIgnoredFolders, $customIgnoredFolders);
-    }
-
-    /**
-     * Get an array of file paths and names which should be ignored.
-     *
-     * @return array
-     */
-    protected function getFilesToIgnore() : array
-    {
-        $defaultFilesToIgnore = [
-            '*.html',
-            '*twig*',
-            '*.blade.php',
-            'blade.php',
-            'server.php',
-            '_ide_helper.php',
-        ];
-
-        $customIgnoredFiles = config('stats.ignore.files');
-
-        return array_merge($defaultFilesToIgnore, $customIgnoredFiles);
     }
 }

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -8,8 +8,13 @@ class ClassFinderTest extends TestCase
 {
     public function getFinder()
     {
-        config()->set('stats.path', [
-            __DIR__.'/../tests/Stubs',
+        config()->set('stats', [
+            'paths' => [
+                __DIR__.'/../tests/Stubs',
+            ],
+            'exclude' => [
+                __DIR__.'/../tests/Stubs/ExcludedFile.php',
+            ]
         ]);
 
         return resolve(ClassFinder::class);
@@ -143,6 +148,14 @@ class ClassFinderTest extends TestCase
 
         $this->assertFalse($classes->contains('stdClass'));
         $this->assertFalse($classes->contains('Exception'));
+    }
+
+    /** @test */
+    public function it_ignores_exluded_file()
+    {
+        $classes = $this->getFinder()->getDeclaredClasses();
+
+        $this->assertFalse($classes->contains('ExcludedFile'));
     }
 
     /** @test */

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -8,10 +8,11 @@ class ClassFinderTest extends TestCase
 {
     public function getFinder()
     {
-        $service = resolve(ClassFinder::class);
-        $service->setBasePath(__DIR__.'/../tests/Stubs');
+        config()->set('stats.path', [
+            __DIR__.'/../tests/Stubs',
+        ]);
 
-        return $service;
+        return resolve(ClassFinder::class);
     }
 
     /** @test */
@@ -150,16 +151,5 @@ class ClassFinderTest extends TestCase
         $classes = $this->getFinder()->getDeclaredClasses();
 
         $this->assertFalse($classes->contains(\Symfony\Component\Finder\Finder::class));
-    }
-
-    /** @test */
-    public function it_ignores_ide_helper_file()
-    {
-        $files = collect(iterator_to_array($this->getFinder()->findFilesInProjectPath()));
-        $files = $files->filter(function($file) {
-            return $file->getFileName() === '_ide_helper.php';
-        });
-
-        $this->assertEquals(0, $files->count());
     }
 }

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -136,16 +136,6 @@ class ClassFinderTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_require_files_which_are_set_to_be_ignored()
-    {
-        $classes = $this->getFinder()->getDeclaredClasses();
-
-        $this->assertFalse($classes->contains('html'));
-        $this->assertFalse($classes->contains('blade'));
-        $this->assertFalse($classes->contains('twig'));
-    }
-
-    /** @test */
     public function it_ignores_native_php_classes()
     {
         $classes = $this->getFinder()->getDeclaredClasses();

--- a/tests/Stubs/ExcludedFile.php
+++ b/tests/Stubs/ExcludedFile.php
@@ -1,0 +1,6 @@
+<?php
+
+class ExcludedFile
+{
+    //
+}

--- a/tests/Stubs/Views/index.blade.php
+++ b/tests/Stubs/Views/index.blade.php
@@ -1,3 +1,0 @@
-<p>
-    This is a Blade View
-</p>

--- a/tests/Stubs/Views/index.html
+++ b/tests/Stubs/Views/index.html
@@ -1,3 +1,0 @@
-<p>
-    This is a HTML View
-</p>

--- a/tests/Stubs/Views/index.twig.php
+++ b/tests/Stubs/Views/index.twig.php
@@ -1,3 +1,0 @@
-<p>
-    This is a Twig View
-</p>


### PR DESCRIPTION
This PR introduces a new way to configure this package.

Config file now looks accordingly:

```php
return [

    /**
     * List of folders to be analyzed.
     */
    'paths' => [
        base_path('app'),
    ],

    /**
     * List of files/folders to be excluded from analysis.
     */
    'exclude' => [
        // base_path('app/helpers.php'),
        // base_path('app/Services'),
    ],

];
```

**stats.paths** option allows users to include any number of folders. By default, `paths` includes only `/app` folder, which is most common.

**stats.ecxlude** option allows users to specify files or folder that should be excluded. By default, `exclude` is empty.

Please note, all paths specified in the config file must be absolute paths (using path helpers). I have included couple of examples.