### PR TITLE
Ignore ide_helper_models file by default

### DIFF
--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -144,6 +144,7 @@ class ClassFinder
             'blade.php',
             'server.php',
             '_ide_helper.php',
+            '_ide_helper_models.php',
         ];
 
         $customIgnoredFiles = config('stats.ignore.files');

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -172,4 +172,15 @@ class ClassFinderTest extends TestCase
 
         $this->assertEquals(0, $files->count());
     }
+
+    /** @test */
+    public function it_ignores_ide_helper_models_file()
+    {
+        $files = collect(iterator_to_array($this->getFinder()->findFilesInProjectPath()));
+        $files = $files->filter(function($file) {
+            return $file->getFileName() === '_ide_helper_models.php';
+        });
+
+        $this->assertEquals(0, $files->count());
+    }
 }

--- a/tests/Stubs/MiscFiles/_ide_helper_models.php
+++ b/tests/Stubs/MiscFiles/_ide_helper_models.php
@@ -1,0 +1,3 @@
+<?php
+
+// This file represent the _ide_helper_models.php file


### PR DESCRIPTION
Same as https://github.com/stefanzweifel/laravel-stats/commit/e2d13f5631071229a24c61fe9bc410fdc60b33a7, but for the helper file that is created for Models.