### PR TITLE
Wrap the require statement in Try/Catch Block

### DIFF
--- a/config/stats.php
+++ b/config/stats.php
@@ -7,6 +7,7 @@ return [
      */
     'paths' => [
         base_path('app'),
+        base_path('database'),
     ],
 
     /**

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -50,7 +50,9 @@ class ClassFinder
 
         $this->findFilesInProjectPath()
             ->each(function ($file) {
-                require_once $file->getRealPath();
+                try {
+                    require_once $file->getRealPath();
+                } catch (Exception $e) {}
             });
 
         ob_end_clean();


### PR DESCRIPTION
While testing the command in real-life apps after merging #42 the command has thrown some exceptions (While requiring Model Factories for example).

I've wrapped the `require_once` statement in a Try/Catch block so the exceptions get caught.

I've also added the `database`-folder to the default array of paths to look for Laravel Components (Otherwise Migrations and Seeders would not show up in the stats-table).