### PR TITLE
Clean up the PHPDoc

### DIFF
--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -10,7 +10,7 @@ use Symfony\Component\Finder\Finder;
 class ClassFinder
 {
     /**
-     * @var Symfony\Component\Finder\Finder
+     * @var \Symfony\Component\Finder\Finder
      */
     protected $finder;
 
@@ -24,7 +24,7 @@ class ClassFinder
      * Classes that belong to the Illuminate and Symfony Namespace
      * are removed from the Collection.
      *
-     * @return Illuminate\Support\Collection
+     * @return Collection
      */
     public function getDeclaredClasses() : Collection
     {
@@ -42,7 +42,7 @@ class ClassFinder
      * We need to use ob_* functions to ensure that
      * loaded files do not output anything.
      *
-     * @return void
+     * @return Collection
      */
     protected function findAndLoadClasses()
     {

--- a/src/Commands/StatsListCommand.php
+++ b/src/Commands/StatsListCommand.php
@@ -24,6 +24,7 @@ class StatsListCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param \Wnx\LaravelStats\Services\StatisticsListService $service
      * @return mixed
      */
     public function handle(StatisticsListService $service)

--- a/src/Component.php
+++ b/src/Component.php
@@ -26,7 +26,6 @@ class Component
      * @param string     $name
      * @param Collection $classes
      *
-     * @return void
      */
     public function __construct(string $name, Collection $classes)
     {

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -24,7 +24,7 @@ class ReflectionClass extends NativeReflectionClass
     }
 
     /**
-     * Determine wether the class uses the given trait.
+     * Determine whether the class uses the given trait.
      *
      * @param  string $name
      * @return bool

--- a/src/Services/StatisticsListService.php
+++ b/src/Services/StatisticsListService.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 class StatisticsListService
 {
     /**
-     * @var Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection
      */
     protected $components;
 
@@ -36,7 +36,7 @@ class StatisticsListService
     /**
      * Return the project statistics as an array.
      *
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
     public function getData()
     {

--- a/src/Statistics/ComponentStatistics.php
+++ b/src/Statistics/ComponentStatistics.php
@@ -8,7 +8,7 @@ use SebastianBergmann\PHPLOC\Analyser;
 class ComponentStatistics
 {
     /**
-     * @var Wnx\LaravelStats\Component
+     * @var \Wnx\LaravelStats\Component
      */
     public $component;
 
@@ -94,7 +94,7 @@ class ComponentStatistics
     /**
      * Return the total number of lines of code.
      *
-     * @return int
+     * @return float
      */
     public function getLinesOfCode() : float
     {

--- a/src/Statistics/ProjectStatistics.php
+++ b/src/Statistics/ProjectStatistics.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 class ProjectStatistics
 {
     /**
-     * @var Illuminate\Support\Collection
+     * @var Collection
      */
     protected $components;
 


### PR DESCRIPTION
Updated the PHPDoc to fit the latest code.

I used just class name if the class importing is declared before class declaration,
if not used fully qualified class name.