### PR TITLE
Patch 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/console": "5.5",
-        "illuminate/support": "5.5",
+        "illuminate/console": "5.5.*",
+        "illuminate/support": "5.5.*",
         "phploc/phploc": "^4.0",
         "symfony/finder": "^3.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/console": "^5.5",
-        "illuminate/support": "^5.5",
+        "illuminate/console": "5.5",
+        "illuminate/support": "5.5",
         "phploc/phploc": "^4.0",
         "symfony/finder": "^3.3"
     },


### PR DESCRIPTION
Laravel doesn't follow semantic versioning. So if say 5.6 breaks your app, composer will still install it because you mentioned `^5.5`. 

When you are releasing a new version that supports both 5.5 & 5.6 you can do
`5.5.* || 5.6.*` 

:smiley: 