### PR TITLE
Move Command class

### DIFF
--- a/src/StatsListCommand.php
+++ b/src/StatsListCommand.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace Wnx\LaravelStats\Commands;
+namespace Wnx\LaravelStats;
 
 use Illuminate\Console\Command;
-use Wnx\LaravelStats\ClassFinder;
 use Wnx\LaravelStats\Formatters\TableOutput;
 use Wnx\LaravelStats\Statistics\ProjectStatistics;
 

--- a/src/StatsServiceProvider.php
+++ b/src/StatsServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Wnx\LaravelStats;
 
 use Illuminate\Support\ServiceProvider;
-use Wnx\LaravelStats\Commands\StatsListCommand;
 
 class StatsServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
This PR moves the `StatsListCommand` class out of the `Commands` folder as there will never be more than one command.

---

#100 yay 🎉 