### PR TITLE
Rename ClassFinder

### DIFF
--- a/src/ComponentFinder.php
+++ b/src/ComponentFinder.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Collection;
 use Symfony\Component\Finder\Finder;
 use Wnx\LaravelStats\Classifiers\Classifier;
 
-class ClassFinder
+class ComponentFinder
 {
     /**
      * Sort classes into Laravel Component.
@@ -17,7 +17,7 @@ class ClassFinder
      *
      * @return Collection
      */
-    public function getComponents()
+    public function get()
     {
         return $this->findAndLoadClasses()
             ->map(function ($class) {

--- a/src/StatsListCommand.php
+++ b/src/StatsListCommand.php
@@ -25,12 +25,12 @@ class StatsListCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param $finder Wnx\LaravelStats\ClassFinder
+     * @param $finder Wnx\LaravelStats\ComponentFinder
      * @return mixed
      */
-    public function handle(ClassFinder $finder)
+    public function handle(ComponentFinder $finder)
     {
-        $statistics = new ProjectStatistics($finder->getComponents());
+        $statistics = new ProjectStatistics($finder->get());
 
         (new TableOutput($this->output))->render($statistics);
     }

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -91,6 +91,8 @@ class ClassifierTest extends TestCase
     /** @test */
     public function it_detects_migrations()
     {
+        require_once __DIR__.'/Stubs/Migrations/2014_10_12_000000_create_users_table.php';
+
         $this->assertSame(
             'Migrations', $this->classifier->classify(new ReflectionClass(\Wnx\LaravelStats\Tests\Stubs\Migrations\CreateUsersTable::class))
         );

--- a/tests/ComponentFinderTest.php
+++ b/tests/ComponentFinderTest.php
@@ -2,9 +2,9 @@
 
 namespace Wnx\LaravelStats\Tests;
 
-use Wnx\LaravelStats\ClassFinder;
+use Wnx\LaravelStats\ComponentFinder;
 
-class ClassFinderTest extends TestCase
+class ComponentFinderTest extends TestCase
 {
     public function setUp()
     {
@@ -19,7 +19,7 @@ class ClassFinderTest extends TestCase
             ],
         ]);
 
-        $this->classes = resolve(ClassFinder::class)->getComponents()->flatten()->pluck('name');
+        $this->classes = resolve(ComponentFinder::class)->get()->flatten()->pluck('name');
     }
 
     /** @test */
@@ -135,7 +135,7 @@ class ClassFinderTest extends TestCase
     /** @test */
     public function it_sorts_classes_into_components()
     {
-        $components = resolve(ClassFinder::class)->getComponents();
+        $components = resolve(ComponentFinder::class)->get();
 
         $this->assertTrue($components->has('Other'));
         $this->assertTrue($components->has('Models'));


### PR DESCRIPTION
This PR renames `ClassFinder` to `ComponentFinder` as this class finds components now as of 6bb850a45351b666466ab65aa044218326cdd465.