### PR TITLE
Refactor ProjectStatistics API

### DIFF
--- a/src/Formatters/TableOutput.php
+++ b/src/Formatters/TableOutput.php
@@ -37,14 +37,12 @@ class TableOutput
     {
         $table = new Table($this->output);
 
-        $rows = $statistics->generate();
-
         $table
             ->setHeaders(['Name', 'Classes', 'Methods', 'Methods/Class', 'Lines', 'LoC', 'LoC/Method'])
-            ->setRows($rows->except('Other')->all())
-            ->addRow($rows->only('Other')->first())
+            ->setRows($statistics->components())
+            ->addRow($statistics->other())
             ->addRow(new TableSeparator)
-            ->addRow($statistics->getTotalRow($rows));
+            ->addRow($statistics->total());
 
         for ($i = 1; $i <= 6; $i++) {
             $table->setColumnStyle($i, (new TableStyle)->setPadType(STR_PAD_LEFT));

--- a/tests/Stubs/ExcludedFile.php
+++ b/tests/Stubs/ExcludedFile.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Wnx\LaravelStats\Tests\Stubs;
+
 class ExcludedFile
 {
     //


### PR DESCRIPTION
This PR cleans up `ProjectStatistics` API. Passing result from `$stats->generate()` to `$stats->getTotalRow()` feels really weird. It suggests that we are missing an abstraction of "ComponentAnalyser". We can take a look into that once the API stabilizes.