### PR TITLE
Make casing of command description consistent with built-in commands

### DIFF
--- a/src/StatsListCommand.php
+++ b/src/StatsListCommand.php
@@ -20,7 +20,7 @@ class StatsListCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Generate Statistics for this Laravel Project';
+    protected $description = 'Generate statistics for this Laravel project';
 
     /**
      * Execute the console command.


### PR DESCRIPTION
As you can see in the screenshot below, the descriptions of the built-in Artisan commands use sentence case. However, `laravel-stats` uses title case for its description, thus being inconsistent with the other commands.

This pull requests simply proposes to fix that :)

![foo](https://user-images.githubusercontent.com/3188746/32028328-5d87eb0c-b9ee-11e7-90c3-a57285ab7970.png)
