### PR TITLE
New Classifier: Event Listener

### DIFF
--- a/src/Classifiers/Classifier.php
+++ b/src/Classifiers/Classifier.php
@@ -14,6 +14,7 @@ class Classifier
         PolicyClassifier::class,
         MiddlewareClassifier::class,
         EventClassifier::class,
+        EventListenerClassifier::class,
         MailClassifier::class,
         NotificationClassifier::class,
         JobClassifier::class,

--- a/src/Classifiers/EventListenerClassifier.php
+++ b/src/Classifiers/EventListenerClassifier.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Wnx\LaravelStats\Classifiers;
+
+use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Tests\Stubs\ServiceProviders\EventServiceProvider;
+
+class EventListenerClassifier extends Classifier
+{
+    public function getName()
+    {
+        return 'Event Listeners';
+    }
+
+    public function satisfies(ReflectionClass $class)
+    {
+        return collect(app()->getProvider(EventServiceProvider::class)->listens())
+            ->collapse()
+            ->unique()
+            ->contains($class->getName());
+    }
+}

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Route;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Classifiers\Classifier;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
+use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
 
 class ClassifierTest extends TestCase
@@ -187,4 +188,13 @@ class ClassifierTest extends TestCase
             'BrowserKit Tests', $this->classifier->classify(new ReflectionClass(DemoBrowserKit::class))
         );
     }
+
+    /** @test */
+    public function it_detects_event_listeners()
+    {
+        $this->assertSame(
+            'Event Listeners', $this->classifier->classify(new ReflectionClass(DemoEventListener::class))
+        );
+    }
+
 }

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Facades\Route;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Classifiers\Classifier;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
-use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
+use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
 
 class ClassifierTest extends TestCase
 {
@@ -196,5 +196,4 @@ class ClassifierTest extends TestCase
             'Event Listeners', $this->classifier->classify(new ReflectionClass(DemoEventListener::class))
         );
     }
-
 }

--- a/tests/Stubs/EventListeners/DemoEventListener.php
+++ b/tests/Stubs/EventListeners/DemoEventListener.php
@@ -2,9 +2,6 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs\EventListeners;
 
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-
 class DemoEventListener
 {
     /**

--- a/tests/Stubs/EventListeners/DemoEventListener.php
+++ b/tests/Stubs/EventListeners/DemoEventListener.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs\EventListeners;
+
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DemoEventListener
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        //
+    }
+}

--- a/tests/Stubs/ServiceProviders/EventServiceProvider.php
+++ b/tests/Stubs/ServiceProviders/EventServiceProvider.php
@@ -2,10 +2,10 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs\ServiceProviders;
 
-use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
-use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
 use Wnx\LaravelStats\Tests\Stubs\Events\DemoEvent;
+use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -16,8 +16,8 @@ class EventServiceProvider extends ServiceProvider
      */
     protected $listen = [
         DemoEvent::class => [
-            DemoEventListener::class
-        ]
+            DemoEventListener::class,
+        ],
     ];
 
     /**

--- a/tests/Stubs/ServiceProviders/EventServiceProvider.php
+++ b/tests/Stubs/ServiceProviders/EventServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs\ServiceProviders;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Event;
+use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
+use Wnx\LaravelStats\Tests\Stubs\Events\DemoEvent;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * The event listener mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [
+        DemoEvent::class => [
+            DemoEventListener::class
+        ]
+    ];
+
+    /**
+     * Register any events for your application.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        parent::boot();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Http\Kernel;
 use Wnx\LaravelStats\StatsServiceProvider;
 use Wnx\LaravelStats\Tests\Stubs\HttpKernel;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Wnx\LaravelStats\Tests\Stubs\ServiceProviders\EventServiceProvider;
 
 abstract class TestCase extends Orchestra
 {
@@ -18,6 +19,7 @@ abstract class TestCase extends Orchestra
     {
         return [
             StatsServiceProvider::class,
+            EventServiceProvider::class
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends Orchestra
     {
         return [
             StatsServiceProvider::class,
-            EventServiceProvider::class
+            EventServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
This PR adds a new `EventListenerClassifier`. The Classifier checks the `$listen` property on the `EventServiceProvider` and will only return `true`if the Listener has been registered.

#### Related Issues 

#75 