### PR TITLE
New Config: Ignore Namespaces

### DIFF
--- a/config/stats.php
+++ b/config/stats.php
@@ -35,7 +35,7 @@ return [
      */
     'rejection_strategy' => \Wnx\LaravelStats\RejectionStrategies\RejectVendorClasses::class,
 
-    /**
+    /*
      * Namespaces which should be ignored.
      * Laravel Stats uses the `starts_with`-string helper, to
      * check if a Namespace should be ignored.
@@ -46,7 +46,7 @@ return [
     'ignored_namespaces' => [
         'Wnx\LaravelStats',
         'Illuminate',
-        'Symfony'
-    ]
+        'Symfony',
+    ],
 
 ];

--- a/config/stats.php
+++ b/config/stats.php
@@ -35,4 +35,18 @@ return [
      */
     'rejection_strategy' => \Wnx\LaravelStats\RejectionStrategies\RejectVendorClasses::class,
 
+    /**
+     * Namespaces which should be ignored.
+     * Laravel Stats uses the `starts_with`-string helper, to
+     * check if a Namespace should be ignored.
+     *
+     * You can use `Illuminate` to ignore the entire `Illuminate`-namespace
+     * or `Illuminate\Support` to ignore a subset of the namespace.
+     */
+    'ignored_namespaces' => [
+        'Wnx\LaravelStats',
+        'Illuminate',
+        'Symfony'
+    ]
+
 ];

--- a/src/ComponentFinder.php
+++ b/src/ComponentFinder.php
@@ -37,10 +37,13 @@ class ComponentFinder
             ->reject(function ($class) {
                 return $this->rejectionStrategy->shouldClassBeRejected($class);
             })
-            ->reject(function($class) {
-                foreach(config('stats.ignored_namespaces', []) as $namespace) {
-                    if (starts_with($class->getNamespaceName(), $namespace)) return true;
+            ->reject(function ($class) {
+                foreach (config('stats.ignored_namespaces', []) as $namespace) {
+                    if (starts_with($class->getNamespaceName(), $namespace)) {
+                        return true;
+                    }
                 }
+
                 return false;
             })
             ->groupBy(function ($class) {

--- a/src/ComponentFinder.php
+++ b/src/ComponentFinder.php
@@ -37,6 +37,12 @@ class ComponentFinder
             ->reject(function ($class) {
                 return $this->rejectionStrategy->shouldClassBeRejected($class);
             })
+            ->reject(function($class) {
+                foreach(config('stats.ignored_namespaces', []) as $namespace) {
+                    if (starts_with($class->getNamespaceName(), $namespace)) return true;
+                }
+                return false;
+            })
             ->groupBy(function ($class) {
                 return (new Classifier)->classify($class);
             });

--- a/tests/Commands/StatsListCommandTest.php
+++ b/tests/Commands/StatsListCommandTest.php
@@ -20,6 +20,7 @@ class StatsListCommandTest extends TestCase
             base_path('app'),
             base_path('database'),
         ]);
+        config()->set('stats.ignored_namespaces', []);
     }
 
     /** @test */

--- a/tests/ComponentFinderTest.php
+++ b/tests/ComponentFinderTest.php
@@ -17,7 +17,9 @@ class ComponentFinderTest extends TestCase
             'exclude' => [
                 __DIR__.'/../tests/Stubs/ExcludedFile.php',
             ],
+            'ignored_namespaces' => []
         ]);
+
 
         $this->classes = resolve(ComponentFinder::class)->get()->flatten()->pluck('name');
     }

--- a/tests/ComponentFinderTest.php
+++ b/tests/ComponentFinderTest.php
@@ -17,9 +17,8 @@ class ComponentFinderTest extends TestCase
             'exclude' => [
                 __DIR__.'/../tests/Stubs/ExcludedFile.php',
             ],
-            'ignored_namespaces' => []
+            'ignored_namespaces' => [],
         ]);
-
 
         $this->classes = resolve(ComponentFinder::class)->get()->flatten()->pluck('name');
     }


### PR DESCRIPTION
This PR adds a new config: `ignored_namespaces`.

If the newly added `RejectInternalClasses`-strategy is used, the packages own Service Provider and Command and all default Laravel Components under the `Illuminate` namespace count toward the project statistics.
This is obviously not a good thing. This new config rejects all classes which belong to a certain namespace (We use the `starts_with`-string helper here).