### PR TITLE
Feature: Custom Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ return [
     ],
 
     /*
+     * List of your custom Classifiers
+     */
+    'custom_component_classifier' => [
+        // \App\Classifiers\CustomerExportClassifier::class
+    ],
+
+    /*
      * The Strategy used to reject Classes from the project statistics.
      *
      * By default all Classes located in
@@ -132,6 +139,45 @@ The package scans the files defined in the `paths`-array in the configuration fi
 | BrowserKit Test | Must extend `Laravel\BrowserKitTesting\TestCase` |
 | PHPUnit Test | Must extend `PHPUnit\Framework\TestCase` |
 
+## Create your own Classifiers
+
+If your application has it's own components you would like to see in `laravel-stats` you can create your own `Classifiers`.
+Create your own Classifiers by implementing the [`Classifier`](https://github.com/stefanzweifel/laravel-stats/blob/master/src/Contracts/Classifier.php)-contract and adding the class to the `stats.custom_component_classifier` config array.
+
+For example:
+
+```php
+// app/Classifiers/RepositoryClassifier.php
+<?php
+
+namespace App\Classifiers;
+
+use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+
+class RepositoryClassifier implements Classifier
+{
+    public function getName() : string
+    {
+        return 'Repository';
+    }
+
+    public function satisfies(ReflectionClass $class) : bool
+    {
+        return $class->isSubclassOf(\App\Repositories\BaseRepository::class);
+    }
+}
+```
+
+```php
+// config/stats.php
+<?php
+    ...
+    'custom_component_classifier' => [
+        \App\Classifiers\RepositoryClassifier::class
+    ],
+    ...
+```
 
 ## Running the tests
 

--- a/config/stats.php
+++ b/config/stats.php
@@ -20,12 +20,7 @@ return [
     ],
 
     /*
-     * List of custom Component Classifiers.
-     *
-     * Your application may contain classes which follow a certain pattern.
-     * With custom Component Classifier you can classifiy those
-     * classes and treat them as first-class citizens
-     * in the project analysis.
+     * List of your custom Classifiers
      */
     'custom_component_classifier' => [
         // \App\Classifiers\CustomerExportClassifier::class

--- a/config/stats.php
+++ b/config/stats.php
@@ -19,7 +19,7 @@ return [
         // base_path('app/Services'),
     ],
 
-    /**
+    /*
      * List of custom Component Classifiers.
      *
      * Your application may contain classes which follow a certain pattern.

--- a/config/stats.php
+++ b/config/stats.php
@@ -19,6 +19,18 @@ return [
         // base_path('app/Services'),
     ],
 
+    /**
+     * List of custom Component Classifiers.
+     *
+     * Your application may contain classes which follow a certain pattern.
+     * With custom Component Classifier you can classifiy those
+     * classes and treat them as first-class citizens
+     * in the project analysis.
+     */
+    'custom_component_classifier' => [
+        // \App\Classifiers\CustomerExportClassifier::class
+    ],
+
     /*
      * The Strategy used to reject Classes from the project statistics.
      *

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -2,26 +2,25 @@
 
 namespace Wnx\LaravelStats;
 
-use Wnx\LaravelStats\Classifiers\BrowserKitTestClassifier;
-use Wnx\LaravelStats\Classifiers\CommandClassifier;
-use Wnx\LaravelStats\Classifiers\ControllerClassifier;
-use Wnx\LaravelStats\Classifiers\DuskClassifier;
-use Wnx\LaravelStats\Classifiers\EventClassifier;
-use Wnx\LaravelStats\Classifiers\EventListenerClassifier;
 use Wnx\LaravelStats\Classifiers\JobClassifier;
+use Wnx\LaravelStats\Classifiers\DuskClassifier;
 use Wnx\LaravelStats\Classifiers\MailClassifier;
-use Wnx\LaravelStats\Classifiers\MiddlewareClassifier;
-use Wnx\LaravelStats\Classifiers\MigrationClassifier;
+use Wnx\LaravelStats\Classifiers\RuleClassifier;
+use Wnx\LaravelStats\Classifiers\EventClassifier;
 use Wnx\LaravelStats\Classifiers\ModelClassifier;
-use Wnx\LaravelStats\Classifiers\NotificationClassifier;
-use Wnx\LaravelStats\Classifiers\PhpUnitClassifier;
 use Wnx\LaravelStats\Classifiers\PolicyClassifier;
+use Wnx\LaravelStats\Classifiers\SeederClassifier;
+use Wnx\LaravelStats\Classifiers\CommandClassifier;
+use Wnx\LaravelStats\Classifiers\PhpUnitClassifier;
 use Wnx\LaravelStats\Classifiers\RequestClassifier;
 use Wnx\LaravelStats\Classifiers\ResourceClassifier;
-use Wnx\LaravelStats\Classifiers\RuleClassifier;
-use Wnx\LaravelStats\Classifiers\SeederClassifier;
+use Wnx\LaravelStats\Classifiers\MigrationClassifier;
+use Wnx\LaravelStats\Classifiers\ControllerClassifier;
+use Wnx\LaravelStats\Classifiers\MiddlewareClassifier;
+use Wnx\LaravelStats\Classifiers\NotificationClassifier;
+use Wnx\LaravelStats\Classifiers\EventListenerClassifier;
+use Wnx\LaravelStats\Classifiers\BrowserKitTestClassifier;
 use Wnx\LaravelStats\Classifiers\ServiceProviderClassifier;
-use Wnx\LaravelStats\ReflectionClass;
 
 class Classifier
 {

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -2,6 +2,7 @@
 
 namespace Wnx\LaravelStats;
 
+use Exception;
 use Wnx\LaravelStats\Classifiers\JobClassifier;
 use Wnx\LaravelStats\Classifiers\DuskClassifier;
 use Wnx\LaravelStats\Classifiers\MailClassifier;
@@ -22,7 +23,6 @@ use Wnx\LaravelStats\Classifiers\EventListenerClassifier;
 use Wnx\LaravelStats\Classifiers\BrowserKitTestClassifier;
 use Wnx\LaravelStats\Classifiers\ServiceProviderClassifier;
 use Wnx\LaravelStats\Contracts\Classifier as ClassifierContract;
-use Exception;
 
 class Classifier
 {
@@ -49,7 +49,7 @@ class Classifier
     ];
 
     /**
-     * Classify a given Class by an available Classifier Strategy
+     * Classify a given Class by an available Classifier Strategy.
      *
      * @param ReflectionClass $class
      * @return string
@@ -64,8 +64,8 @@ class Classifier
         foreach ($mergedClassifiers as $classifier) {
             $c = new $classifier();
 
-            if (!$this->implementsContract($classifier)) {
-                throw new Exception("Classifier {$classifier} does not implement " . ClassifierContract::class . ".");
+            if (! $this->implementsContract($classifier)) {
+                throw new Exception("Classifier {$classifier} does not implement ".ClassifierContract::class.'.');
             }
 
             if ($c->satisfies($class)) {
@@ -77,7 +77,7 @@ class Classifier
     }
 
     /**
-     * Check if a class implements our Classifier Contract
+     * Check if a class implements our Classifier Contract.
      * @param  class $classifier
      * @return bool
      */

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -1,7 +1,26 @@
 <?php
 
-namespace Wnx\LaravelStats\Classifiers;
+namespace Wnx\LaravelStats;
 
+use Wnx\LaravelStats\Classifiers\BrowserKitTestClassifier;
+use Wnx\LaravelStats\Classifiers\CommandClassifier;
+use Wnx\LaravelStats\Classifiers\ControllerClassifier;
+use Wnx\LaravelStats\Classifiers\DuskClassifier;
+use Wnx\LaravelStats\Classifiers\EventClassifier;
+use Wnx\LaravelStats\Classifiers\EventListenerClassifier;
+use Wnx\LaravelStats\Classifiers\JobClassifier;
+use Wnx\LaravelStats\Classifiers\MailClassifier;
+use Wnx\LaravelStats\Classifiers\MiddlewareClassifier;
+use Wnx\LaravelStats\Classifiers\MigrationClassifier;
+use Wnx\LaravelStats\Classifiers\ModelClassifier;
+use Wnx\LaravelStats\Classifiers\NotificationClassifier;
+use Wnx\LaravelStats\Classifiers\PhpUnitClassifier;
+use Wnx\LaravelStats\Classifiers\PolicyClassifier;
+use Wnx\LaravelStats\Classifiers\RequestClassifier;
+use Wnx\LaravelStats\Classifiers\ResourceClassifier;
+use Wnx\LaravelStats\Classifiers\RuleClassifier;
+use Wnx\LaravelStats\Classifiers\SeederClassifier;
+use Wnx\LaravelStats\Classifiers\ServiceProviderClassifier;
 use Wnx\LaravelStats\ReflectionClass;
 
 class Classifier

--- a/src/Classifiers/BrowserKitTestClassifier.php
+++ b/src/Classifiers/BrowserKitTestClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Laravel\BrowserKitTesting\TestCase;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class BrowserKitTestClassifier extends Classifier
+class BrowserKitTestClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'BrowserKit Tests';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return class_exists(TestCase::class) && $class->isSubclassOf(TestCase::class);
     }

--- a/src/Classifiers/BrowserKitTestClassifier.php
+++ b/src/Classifiers/BrowserKitTestClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Laravel\BrowserKitTesting\TestCase;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class BrowserKitTestClassifier extends BaseClassifier implements Classifier
+class BrowserKitTestClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/Classifier.php
+++ b/src/Classifiers/Classifier.php
@@ -6,7 +6,7 @@ use Wnx\LaravelStats\ReflectionClass;
 
 class Classifier
 {
-    const CLASSIFIERS = [
+    const DEFAULT_CLASSIFIER = [
         ControllerClassifier::class,
         ModelClassifier::class,
         CommandClassifier::class,
@@ -30,7 +30,10 @@ class Classifier
 
     public function classify(ReflectionClass $class)
     {
-        foreach (self::CLASSIFIERS as $classifier) {
+        $customClassifiers = config('stats.custom_component_classifier', []);
+        $mergedClassifiers = array_merge(self::DEFAULT_CLASSIFIER, $customClassifiers);
+
+        foreach ($mergedClassifiers as $classifier) {
             $c = new $classifier();
 
             if ($c->satisfies($class)) {

--- a/src/Classifiers/CommandClassifier.php
+++ b/src/Classifiers/CommandClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Illuminate\Console\Command;
 use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class CommandClassifier extends Classifier
+class CommandClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Commands';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(Command::class);
     }

--- a/src/Classifiers/CommandClassifier.php
+++ b/src/Classifiers/CommandClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Illuminate\Console\Command;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class CommandClassifier extends BaseClassifier implements Classifier
+class CommandClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/ControllerClassifier.php
+++ b/src/Classifiers/ControllerClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Illuminate\Routing\Router;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class ControllerClassifier extends BaseClassifier implements Classifier
+class ControllerClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/ControllerClassifier.php
+++ b/src/Classifiers/ControllerClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Illuminate\Routing\Router;
 use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class ControllerClassifier extends Classifier
+class ControllerClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Controllers';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return collect(resolve(Router::class)->getRoutes())
             ->reject(function ($route) {

--- a/src/Classifiers/DuskClassifier.php
+++ b/src/Classifiers/DuskClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Laravel\Dusk\TestCase;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class DuskClassifier extends BaseClassifier implements Classifier
+class DuskClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/DuskClassifier.php
+++ b/src/Classifiers/DuskClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Laravel\Dusk\TestCase;
 use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class DuskClassifier extends Classifier
+class DuskClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'DuskTests';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return class_exists(TestCase::class) && $class->isSubclassOf(TestCase::class);
     }

--- a/src/Classifiers/EventClassifier.php
+++ b/src/Classifiers/EventClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
 use Illuminate\Foundation\Events\Dispatchable;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class EventClassifier extends BaseClassifier implements Classifier
+class EventClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/EventClassifier.php
+++ b/src/Classifiers/EventClassifier.php
@@ -3,8 +3,8 @@
 namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Illuminate\Foundation\Events\Dispatchable;
 use Wnx\LaravelStats\Contracts\Classifier;
+use Illuminate\Foundation\Events\Dispatchable;
 use Wnx\LaravelStats\Classifier as BaseClassifier;
 
 class EventClassifier extends BaseClassifier implements Classifier

--- a/src/Classifiers/EventClassifier.php
+++ b/src/Classifiers/EventClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Foundation\Events\Dispatchable;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class EventClassifier extends Classifier
+class EventClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Events';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->usesTrait(Dispatchable::class);
     }

--- a/src/Classifiers/EventListenerClassifier.php
+++ b/src/Classifiers/EventListenerClassifier.php
@@ -3,9 +3,9 @@
 namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Wnx\LaravelStats\Contracts\Classifier;
 use Wnx\LaravelStats\Classifier as BaseClassifier;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 
 class EventListenerClassifier extends BaseClassifier implements Classifier
 {

--- a/src/Classifiers/EventListenerClassifier.php
+++ b/src/Classifiers/EventListenerClassifier.php
@@ -4,10 +4,9 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 
-class EventListenerClassifier extends BaseClassifier implements Classifier
+class EventListenerClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/EventListenerClassifier.php
+++ b/src/Classifiers/EventListenerClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class EventListenerClassifier extends Classifier
+class EventListenerClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Event Listeners';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return collect(app()->getProvider(EventServiceProvider::class)->listens())
             ->collapse()

--- a/src/Classifiers/JobClassifier.php
+++ b/src/Classifiers/JobClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class JobClassifier extends Classifier
+class JobClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Jobs';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->usesTrait(Dispatchable::class);
     }

--- a/src/Classifiers/JobClassifier.php
+++ b/src/Classifiers/JobClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class JobClassifier extends BaseClassifier implements Classifier
+class JobClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/JobClassifier.php
+++ b/src/Classifiers/JobClassifier.php
@@ -3,8 +3,8 @@
 namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Illuminate\Foundation\Bus\Dispatchable;
 use Wnx\LaravelStats\Contracts\Classifier;
+use Illuminate\Foundation\Bus\Dispatchable;
 use Wnx\LaravelStats\Classifier as BaseClassifier;
 
 class JobClassifier extends BaseClassifier implements Classifier

--- a/src/Classifiers/MailClassifier.php
+++ b/src/Classifiers/MailClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Contracts\Mail\Mailable;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class MailClassifier extends BaseClassifier implements Classifier
+class MailClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/MailClassifier.php
+++ b/src/Classifiers/MailClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Contracts\Mail\Mailable;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class MailClassifier extends Classifier
+class MailClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Mails';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(Mailable::class);
     }

--- a/src/Classifiers/MiddlewareClassifier.php
+++ b/src/Classifiers/MiddlewareClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Illuminate\Contracts\Http\Kernel;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class MiddlewareClassifier extends BaseClassifier implements Classifier
+class MiddlewareClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/MiddlewareClassifier.php
+++ b/src/Classifiers/MiddlewareClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Illuminate\Contracts\Http\Kernel;
 use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class MiddlewareClassifier extends Classifier
+class MiddlewareClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Middlewares';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         $kernel = resolve(Kernel::class);
 

--- a/src/Classifiers/MigrationClassifier.php
+++ b/src/Classifiers/MigrationClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Database\Migrations\Migration;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class MigrationClassifier extends Classifier
+class MigrationClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Migrations';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(Migration::class);
     }

--- a/src/Classifiers/MigrationClassifier.php
+++ b/src/Classifiers/MigrationClassifier.php
@@ -3,8 +3,8 @@
 namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Illuminate\Database\Migrations\Migration;
 use Wnx\LaravelStats\Contracts\Classifier;
+use Illuminate\Database\Migrations\Migration;
 use Wnx\LaravelStats\Classifier as BaseClassifier;
 
 class MigrationClassifier extends BaseClassifier implements Classifier

--- a/src/Classifiers/MigrationClassifier.php
+++ b/src/Classifiers/MigrationClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
 use Illuminate\Database\Migrations\Migration;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class MigrationClassifier extends BaseClassifier implements Classifier
+class MigrationClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/ModelClassifier.php
+++ b/src/Classifiers/ModelClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Database\Eloquent\Model;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class ModelClassifier extends BaseClassifier implements Classifier
+class ModelClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/ModelClassifier.php
+++ b/src/Classifiers/ModelClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Database\Eloquent\Model;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class ModelClassifier extends Classifier
+class ModelClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Models';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(Model::class);
     }

--- a/src/Classifiers/NotificationClassifier.php
+++ b/src/Classifiers/NotificationClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Notifications\Notification;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class NotificationClassifier extends BaseClassifier implements Classifier
+class NotificationClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/NotificationClassifier.php
+++ b/src/Classifiers/NotificationClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Notifications\Notification;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class NotificationClassifier extends Classifier
+class NotificationClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Notifications';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(Notification::class);
     }

--- a/src/Classifiers/PhpUnitClassifier.php
+++ b/src/Classifiers/PhpUnitClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use PHPUnit\Framework\TestCase;
 use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class PhpUnitClassifier extends Classifier
+class PhpUnitClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'PHPUnit Tests';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return class_exists(TestCase::class) && $class->isSubclassOf(TestCase::class);
     }

--- a/src/Classifiers/PhpUnitClassifier.php
+++ b/src/Classifiers/PhpUnitClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use PHPUnit\Framework\TestCase;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class PhpUnitClassifier extends BaseClassifier implements Classifier
+class PhpUnitClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/PolicyClassifier.php
+++ b/src/Classifiers/PolicyClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class PolicyClassifier extends BaseClassifier implements Classifier
+class PolicyClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/PolicyClassifier.php
+++ b/src/Classifiers/PolicyClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Contracts\Auth\Access\Gate;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class PolicyClassifier extends Classifier
+class PolicyClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Policies';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return in_array(
             $class->getName(), resolve(Gate::class)->policies()

--- a/src/Classifiers/RequestClassifier.php
+++ b/src/Classifiers/RequestClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
 use Illuminate\Foundation\Http\FormRequest;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class RequestClassifier extends BaseClassifier implements Classifier
+class RequestClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/RequestClassifier.php
+++ b/src/Classifiers/RequestClassifier.php
@@ -3,8 +3,8 @@
 namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Illuminate\Foundation\Http\FormRequest;
 use Wnx\LaravelStats\Contracts\Classifier;
+use Illuminate\Foundation\Http\FormRequest;
 use Wnx\LaravelStats\Classifier as BaseClassifier;
 
 class RequestClassifier extends BaseClassifier implements Classifier

--- a/src/Classifiers/RequestClassifier.php
+++ b/src/Classifiers/RequestClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Foundation\Http\FormRequest;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class RequestClassifier extends Classifier
+class RequestClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Requests';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(FormRequest::class);
     }

--- a/src/Classifiers/ResourceClassifier.php
+++ b/src/Classifiers/ResourceClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Http\Resources\Json\Resource;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class ResourceClassifier extends Classifier
+class ResourceClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Resources';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(Resource::class);
     }

--- a/src/Classifiers/ResourceClassifier.php
+++ b/src/Classifiers/ResourceClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
 use Illuminate\Http\Resources\Json\Resource;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class ResourceClassifier extends BaseClassifier implements Classifier
+class ResourceClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/ResourceClassifier.php
+++ b/src/Classifiers/ResourceClassifier.php
@@ -3,8 +3,8 @@
 namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Illuminate\Http\Resources\Json\Resource;
 use Wnx\LaravelStats\Contracts\Classifier;
+use Illuminate\Http\Resources\Json\Resource;
 use Wnx\LaravelStats\Classifier as BaseClassifier;
 
 class ResourceClassifier extends BaseClassifier implements Classifier

--- a/src/Classifiers/RuleClassifier.php
+++ b/src/Classifiers/RuleClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Contracts\Validation\Rule;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class RuleClassifier extends BaseClassifier implements Classifier
+class RuleClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/RuleClassifier.php
+++ b/src/Classifiers/RuleClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Contracts\Validation\Rule;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class RuleClassifier extends Classifier
+class RuleClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Rules';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->implementsInterface(Rule::class);
     }

--- a/src/Classifiers/SeederClassifier.php
+++ b/src/Classifiers/SeederClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Illuminate\Database\Seeder;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class SeederClassifier extends BaseClassifier implements Classifier
+class SeederClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/SeederClassifier.php
+++ b/src/Classifiers/SeederClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Illuminate\Database\Seeder;
 use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class SeederClassifier extends Classifier
+class SeederClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Seeders';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(Seeder::class);
     }

--- a/src/Classifiers/ServiceProviderClassifier.php
+++ b/src/Classifiers/ServiceProviderClassifier.php
@@ -5,9 +5,8 @@ namespace Wnx\LaravelStats\Classifiers;
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Support\ServiceProvider;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class ServiceProviderClassifier extends BaseClassifier implements Classifier
+class ServiceProviderClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/src/Classifiers/ServiceProviderClassifier.php
+++ b/src/Classifiers/ServiceProviderClassifier.php
@@ -4,15 +4,17 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Support\ServiceProvider;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\Classifier as BaseClassifier;
 
-class ServiceProviderClassifier extends Classifier
+class ServiceProviderClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'Service Providers';
     }
 
-    public function satisfies(ReflectionClass $class)
+    public function satisfies(ReflectionClass $class) : bool
     {
         return $class->isSubclassOf(ServiceProvider::class);
     }

--- a/src/ComponentFinder.php
+++ b/src/ComponentFinder.php
@@ -6,7 +6,6 @@ use Exception;
 use SplFileInfo;
 use Illuminate\Support\Collection;
 use Symfony\Component\Finder\Finder;
-use Wnx\LaravelStats\Classifier;
 use Wnx\LaravelStats\RejectionStrategies\RejectVendorClasses;
 
 class ComponentFinder

--- a/src/ComponentFinder.php
+++ b/src/ComponentFinder.php
@@ -6,7 +6,7 @@ use Exception;
 use SplFileInfo;
 use Illuminate\Support\Collection;
 use Symfony\Component\Finder\Finder;
-use Wnx\LaravelStats\Classifiers\Classifier;
+use Wnx\LaravelStats\Classifier;
 use Wnx\LaravelStats\RejectionStrategies\RejectVendorClasses;
 
 class ComponentFinder

--- a/src/Contracts/Classifier.php
+++ b/src/Contracts/Classifier.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Wnx\LaravelStats\Contracts;
+
+use Wnx\LaravelStats\ReflectionClass;
+
+interface Classifier
+{
+    /**
+     * Component Name displayed in the results
+     *
+     * @return String
+     */
+    public function getName() : String;
+
+    /**
+     * Determine if the given Class should be classified
+     * as the component the Classifier Class represents
+     *
+     * @param ReflectionClass $class
+     * @return bool
+     */
+    public function satisfies(ReflectionClass $class) : bool;
+}

--- a/src/Contracts/Classifier.php
+++ b/src/Contracts/Classifier.php
@@ -11,7 +11,7 @@ interface Classifier
      *
      * @return string
      */
-    public function getName() : String;
+    public function getName() : string;
 
     /**
      * Determine if the given Class should be classified

--- a/src/Contracts/Classifier.php
+++ b/src/Contracts/Classifier.php
@@ -7,15 +7,15 @@ use Wnx\LaravelStats\ReflectionClass;
 interface Classifier
 {
     /**
-     * Component Name displayed in the results
+     * Component Name displayed in the results.
      *
-     * @return String
+     * @return string
      */
     public function getName() : String;
 
     /**
      * Determine if the given Class should be classified
-     * as the component the Classifier Class represents
+     * as the component the Classifier Class represents.
      *
      * @param ReflectionClass $class
      * @return bool

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -9,6 +9,8 @@ use Wnx\LaravelStats\Classifiers\Classifier;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
 use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
+use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClass;
+use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClassifier;
 
 class ClassifierTest extends TestCase
 {
@@ -196,4 +198,18 @@ class ClassifierTest extends TestCase
             'Event Listeners', $this->classifier->classify(new ReflectionClass(DemoEventListener::class))
         );
     }
+
+    /** @test */
+    public function it_detects_custom_components()
+    {
+        config()->set('stats.custom_component_classifier', [
+            MyCustomComponentClassifier::class
+        ]);
+
+        $this->assertSame(
+            'My Custom Component',
+            $this->classifier->classify(new ReflectionClass(MyCustomComponentClass::class))
+        );
+    }
+
 }

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -2,15 +2,16 @@
 
 namespace Wnx\LaravelStats\Tests;
 
-use Wnx\LaravelStats\Classifier;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
+use Wnx\LaravelStats\Classifier;
 use Wnx\LaravelStats\ReflectionClass;
-use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
-use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
+use Wnx\LaravelStats\StatsListCommand;
+use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
 use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClass;
 use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClassifier;
-use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
+use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
+use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
 
 class ClassifierTest extends TestCase
 {
@@ -210,5 +211,17 @@ class ClassifierTest extends TestCase
             'My Custom Component',
             $this->classifier->classify(new ReflectionClass(MyCustomComponentClass::class))
         );
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_a_custom_component_classifier_does_not_follow_the_contract()
+    {
+        $this->expectException(\Exception::class);
+
+        config()->set('stats.custom_component_classifier', [
+            StatsListCommand::class
+        ]);
+
+        $this->classifier->classify(new ReflectionClass(MyCustomComponentClass::class));
     }
 }

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -5,7 +5,7 @@ namespace Wnx\LaravelStats\Tests;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Wnx\LaravelStats\ReflectionClass;
-use Wnx\LaravelStats\Classifiers\Classifier;
+use Wnx\LaravelStats\Classifier;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
 use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClass;

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -8,9 +8,9 @@ use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Classifiers\Classifier;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
-use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
 use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClass;
 use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClassifier;
+use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
 
 class ClassifierTest extends TestCase
 {
@@ -203,7 +203,7 @@ class ClassifierTest extends TestCase
     public function it_detects_custom_components()
     {
         config()->set('stats.custom_component_classifier', [
-            MyCustomComponentClassifier::class
+            MyCustomComponentClassifier::class,
         ]);
 
         $this->assertSame(
@@ -211,5 +211,4 @@ class ClassifierTest extends TestCase
             $this->classifier->classify(new ReflectionClass(MyCustomComponentClass::class))
         );
     }
-
 }

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -2,10 +2,10 @@
 
 namespace Wnx\LaravelStats\Tests;
 
+use Wnx\LaravelStats\Classifier;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Wnx\LaravelStats\ReflectionClass;
-use Wnx\LaravelStats\Classifier;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
 use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
 use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClass;

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -2,16 +2,16 @@
 
 namespace Wnx\LaravelStats\Tests;
 
+use Wnx\LaravelStats\Classifier;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
-use Wnx\LaravelStats\Classifier;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\StatsListCommand;
-use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
+use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
+use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
 use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClass;
 use Wnx\LaravelStats\Tests\Stubs\MyCustomComponentClassifier;
-use Wnx\LaravelStats\Tests\Stubs\Tests\DemoBrowserKit;
-use Wnx\LaravelStats\Tests\Stubs\Tests\DemoDuskTest;
+use Wnx\LaravelStats\Tests\Stubs\EventListeners\DemoEventListener;
 
 class ClassifierTest extends TestCase
 {
@@ -219,7 +219,7 @@ class ClassifierTest extends TestCase
         $this->expectException(\Exception::class);
 
         config()->set('stats.custom_component_classifier', [
-            StatsListCommand::class
+            StatsListCommand::class,
         ]);
 
         $this->classifier->classify(new ReflectionClass(MyCustomComponentClass::class));

--- a/tests/Stubs/MyCustomComponentClass.php
+++ b/tests/Stubs/MyCustomComponentClass.php
@@ -2,8 +2,7 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs;
 
-class MyCustomComponentClass {
-
+class MyCustomComponentClass
+{
     public $foo = 'bar';
-
 }

--- a/tests/Stubs/MyCustomComponentClass.php
+++ b/tests/Stubs/MyCustomComponentClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs;
+
+class MyCustomComponentClass {
+
+    public $foo = 'bar';
+
+}

--- a/tests/Stubs/MyCustomComponentClassifier.php
+++ b/tests/Stubs/MyCustomComponentClassifier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs;
+
+use Wnx\LaravelStats\ReflectionClass;
+
+
+class MyCustomComponentClassifier
+{
+
+    public function getName()
+    {
+        return 'My Custom Component';
+    }
+
+    public function satisfies(ReflectionClass $class) : bool
+    {
+        return $class->hasProperty('foo');
+    }
+}

--- a/tests/Stubs/MyCustomComponentClassifier.php
+++ b/tests/Stubs/MyCustomComponentClassifier.php
@@ -2,11 +2,13 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs;
 
+use Wnx\LaravelStats\Classifier as BaseClassifier;
+use Wnx\LaravelStats\Contracts\Classifier;
 use Wnx\LaravelStats\ReflectionClass;
 
-class MyCustomComponentClassifier
+class MyCustomComponentClassifier extends BaseClassifier implements Classifier
 {
-    public function getName()
+    public function getName() : string
     {
         return 'My Custom Component';
     }

--- a/tests/Stubs/MyCustomComponentClassifier.php
+++ b/tests/Stubs/MyCustomComponentClassifier.php
@@ -2,8 +2,8 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs;
 
-use Wnx\LaravelStats\Contracts\Classifier;
 use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
 
 class MyCustomComponentClassifier implements Classifier
 {

--- a/tests/Stubs/MyCustomComponentClassifier.php
+++ b/tests/Stubs/MyCustomComponentClassifier.php
@@ -2,11 +2,10 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs;
 
-use Wnx\LaravelStats\Classifier as BaseClassifier;
 use Wnx\LaravelStats\Contracts\Classifier;
 use Wnx\LaravelStats\ReflectionClass;
 
-class MyCustomComponentClassifier extends BaseClassifier implements Classifier
+class MyCustomComponentClassifier implements Classifier
 {
     public function getName() : string
     {

--- a/tests/Stubs/MyCustomComponentClassifier.php
+++ b/tests/Stubs/MyCustomComponentClassifier.php
@@ -4,10 +4,8 @@ namespace Wnx\LaravelStats\Tests\Stubs;
 
 use Wnx\LaravelStats\ReflectionClass;
 
-
 class MyCustomComponentClassifier
 {
-
     public function getName()
     {
         return 'My Custom Component';


### PR DESCRIPTION
**Work in Progress**

This PR adds a new feature to `laravel-stats`. It will allow users to define their own classifiers in the `stats.php` config file.
Custom Component Classifiers will have to implement the `Classifier` contract.

### TODOs:

- [x] Refactor built in Classifiers to implement `Classifier`-Contract
- [x] Cleanup the `src/Classifiers/Classifier.php`
- [x] Update Docs for README
