### PR TITLE
Change Version Contraints to Support Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/console": "5.5.*",
-        "illuminate/support": "5.5.*",
-        "phploc/phploc": "^4.0",
-        "symfony/finder": "^3.3"
+        "illuminate/console": "~5.5",
+        "illuminate/support": "~5.5",
+        "phploc/phploc": "~4.0",
+        "symfony/finder": "~3.3|~4.0"
     },
     "require-dev": {
-        "laravel/browser-kit-testing": "^2.0",
-        "laravel/dusk": "^2.0",
-        "orchestra/testbench": "^3.5",
+        "laravel/browser-kit-testing": "~2.0",
+        "laravel/dusk": "~2.0",
+        "orchestra/testbench": "~3.5",
         "phpunit/phpunit": "6.*"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds support for Laravel 5.6.
I will merge and release a new version after Laravel 5.6 has been officially released on February 7th 2018.

refs #118 