### PR TITLE
Wrap satisfies in rescue funcion callback

### DIFF
--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -70,7 +70,7 @@ class Classifier
 
             // Wrap the `satisfies` method call in the `resuce` helper to
             // catch possible thrown Exceptions
-            $satisfied = rescue(function() use ($c, $class) {
+            $satisfied = rescue(function () use ($c, $class) {
                 return $c->satisfies($class);
             }, false);
 

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -68,7 +68,13 @@ class Classifier
                 throw new Exception("Classifier {$classifier} does not implement ".ClassifierContract::class.'.');
             }
 
-            if ($c->satisfies($class)) {
+            // Wrap the `satisfies` method call in the `resuce` helper to
+            // catch possible thrown Exceptions
+            $satisfied = rescue(function() use ($c, $class) {
+                return $c->satisfies($class);
+            }, false);
+
+            if ($satisfied) {
                 return $c->getName();
             }
         }


### PR DESCRIPTION
In a project of mine, certain Service Providers have been disabled (eg. the AuthServiceProvider). When the `stats` command is run it fails, as some classes and helpers have not been created during the boot of the framework.

Luckily, Laravel comes with a handy [`rescue`](https://laravel.com/docs/5.6/helpers#method-rescue) function. When the `satisfies`-method on a `Classifiers` throws an exception, the exception is catched in the rescue function and the `$satisfies` value falls back to `false`.