### PR TITLE
Add Laravel 5.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/stefanzweifel/laravel-stats/compare/v1.7.1...HEAD)
 
+### Changed
+- Changed Version Contraints in `composer.json` to support Laravel 5.7 [#125](https://github.com/stefanzweifel/laravel-stats/pull/125)
 
 ## [v1.7.1](https://github.com/stefanzweifel/laravel-stats/compare/v1.7.0...v1.7.1) - 2018-04-16
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "symfony/finder": "~3.3|~4.0"
     },
     "require-dev": {
-        "laravel/dusk": "~2.0|~3.0",
         "laravel/browser-kit-testing": "~2.0|~3.0|~4.0",
+        "laravel/dusk": "~2.0|~3.0|~4.0",
         "orchestra/testbench": "~3.5",
         "phpunit/phpunit": "6.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/console": "~5.5.0|~5.6.0",
-        "illuminate/support": "~5.5.0|~5.6.0",
+        "illuminate/console": "~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0",
         "phploc/phploc": "~4.0",
         "symfony/finder": "~3.3|~4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "symfony/finder": "~3.3|~4.0"
     },
     "require-dev": {
-        "laravel/browser-kit-testing": "~2.0",
         "laravel/dusk": "~2.0|~3.0",
+        "laravel/browser-kit-testing": "~2.0|~3.0|~4.0",
         "orchestra/testbench": "~3.5",
         "phpunit/phpunit": "6.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "laravel/browser-kit-testing": "~2.0|~3.0|~4.0",
         "laravel/dusk": "~2.0|~3.0|~4.0",
         "orchestra/testbench": "~3.5",
-        "phpunit/phpunit": "7.*"
+        "phpunit/phpunit": "6.*|7.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "laravel/browser-kit-testing": "~2.0|~3.0|~4.0",
         "laravel/dusk": "~2.0|~3.0|~4.0",
         "orchestra/testbench": "~3.5",
-        "phpunit/phpunit": "6.*"
+        "phpunit/phpunit": "7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds support for Laravel 5.7 and also updates other Laravel related dependencies.

Closes #123 