### PR TITLE
Test package against multiple Laravel and PHP Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ matrix:
   include:
     - php: 7.0
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
-    - php: 7.0
-      env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
-    - php: 7.0
-      env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
     - php: 7.1
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,53 @@
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 language: php
+
 sudo: false
+
 dist: trusty
 
-php:
-  - 7.0
-  - 7.1
-  - 7.2
+env:
+  global:
+    - COVERAGE=0
+
+matrix:
+  include:
+    - php: 7.0
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+    - php: 7.0
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
+    - php: 7.0
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.1
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+    - php: 7.1
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
+    - php: 7.1
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.2
+      env: LARAVEL='5.5.* 'TESTBENCH='3.5.*'
+    - php: 7.2
+      env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
+    - php: 7.2
+      env: COVERAGE=1 LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
+  fast_finish: true
 
 before_script:
-  - phpenv config-rm xdebug.ini
-  - travis_retry composer install --prefer-dist --no-interaction
+    - phpenv config-rm xdebug.ini
+    - composer config discard-changes true
+    - if [[ $COVERAGE = '1' ]]; then ./bin/codeclimate setup; fi
 
-script: phpunit
+before_install:
+  - travis_retry composer self-update
+  - travis_retry composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" --no-interaction --no-update
+
+install:
+  - travis_retry composer install --prefer-dist --no-interaction --no-suggest
+
+script:
+  - vendor/bin/phpunit
+
+after_success:
+  - if [[ $COVERAGE = 1 ]]; then ./bin/codeclimate report $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,12 @@ matrix:
     - php: 7.2
       env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
     - php: 7.2
-      env: COVERAGE=1 LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
+      env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
   fast_finish: true
 
 before_script:
     - phpenv config-rm xdebug.ini
     - composer config discard-changes true
-    - if [[ $COVERAGE = '1' ]]; then ./bin/codeclimate setup; fi
 
 before_install:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ sudo: false
 
 dist: trusty
 
-env:
-  global:
-    - COVERAGE=0
-
 matrix:
   include:
     - php: 7.0
@@ -43,6 +39,3 @@ install:
 
 script:
   - vendor/bin/phpunit
-
-after_success:
-  - if [[ $COVERAGE = 1 ]]; then ./bin/codeclimate report $TRAVIS_TEST_RESULT; fi

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "laravel/browser-kit-testing": "~2.0|~3.0|~4.0",
         "laravel/dusk": "~2.0|~3.0|~4.0",
+        "mockery/mockery": "^1.1",
         "orchestra/testbench": "^3.5|^3.6|^3.7",
         "phpunit/phpunit": "6.*|7.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "laravel/browser-kit-testing": "~2.0|~3.0|~4.0",
         "laravel/dusk": "~2.0|~3.0|~4.0",
-        "orchestra/testbench": "~3.5",
+        "orchestra/testbench": "^3.5|^3.6|^3.7",
         "phpunit/phpunit": "6.*|7.*"
     },
     "autoload": {

--- a/tests/Commands/StatsListCommandTest.php
+++ b/tests/Commands/StatsListCommandTest.php
@@ -26,6 +26,8 @@ class StatsListCommandTest extends TestCase
     /** @test */
     public function it_works()
     {
+        $this->markTestSkipped('No longer works in Laravel 5.7');
+
         Route::get('projects', 'Wnx\LaravelStats\Tests\Stubs\Controllers\ProjectsController@index');
         Route::get('users', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@index');
 
@@ -43,6 +45,8 @@ class StatsListCommandTest extends TestCase
     /** @test */
     public function it_displays_all_headers()
     {
+        $this->markTestSkipped('No longer works in Laravel 5.7');
+
         $this->overrideConfig();
 
         $this->artisan('stats');
@@ -60,6 +64,8 @@ class StatsListCommandTest extends TestCase
     /** @test */
     public function it_returns_stats_as_json()
     {
+        $this->markTestSkipped('No longer works in Laravel 5.7');
+
         $this->overrideConfig();
 
         $this->artisan('stats', [

--- a/tests/Commands/StatsListCommandTest.php
+++ b/tests/Commands/StatsListCommandTest.php
@@ -17,7 +17,7 @@ class StatsListCommandTest extends TestCase
             $this->withoutMockingConsoleOutput();
         }
 
-        /**
+        /*
          * Override stats.path confiugration to not include `tests` folder
          * This fixes the issue, that orchestra does not ship with the
          * default `tests` folder and would throw an error, because

--- a/tests/Commands/StatsListCommandTest.php
+++ b/tests/Commands/StatsListCommandTest.php
@@ -8,19 +8,21 @@ use Illuminate\Support\Facades\Artisan;
 
 class StatsListCommandTest extends TestCase
 {
-    /**
-     * Override stats.path confiugration to not include `tests` folder
-     * This fixes the issue, that orchestra does not ship with the
-     * default `tests` folder and would throw an error, because
-     * the path does not exist.
-     */
-    public function overrideConfig()
+    public function setUp()
     {
+        parent::setUp();
+
         // See https://github.com/orchestral/testbench/issues/229#issuecomment-419716531
         if (starts_with($this->app->version(), '5.7')) {
             $this->withoutMockingConsoleOutput();
         }
 
+        /**
+         * Override stats.path confiugration to not include `tests` folder
+         * This fixes the issue, that orchestra does not ship with the
+         * default `tests` folder and would throw an error, because
+         * the path does not exist.
+         */
         config()->set('stats.paths', [
             base_path('app'),
             base_path('database'),
@@ -34,8 +36,6 @@ class StatsListCommandTest extends TestCase
         Route::get('projects', 'Wnx\LaravelStats\Tests\Stubs\Controllers\ProjectsController@index');
         Route::get('users', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@index');
 
-        $this->overrideConfig();
-
         $this->artisan('stats');
         $resultAsText = Artisan::output();
 
@@ -48,8 +48,6 @@ class StatsListCommandTest extends TestCase
     /** @test */
     public function it_displays_all_headers()
     {
-        $this->overrideConfig();
-
         $this->artisan('stats');
         $result = Artisan::output();
 
@@ -65,8 +63,6 @@ class StatsListCommandTest extends TestCase
     /** @test */
     public function it_returns_stats_as_json()
     {
-        $this->overrideConfig();
-
         $this->artisan('stats', [
             '--format' => 'json',
         ]);

--- a/tests/Commands/StatsListCommandTest.php
+++ b/tests/Commands/StatsListCommandTest.php
@@ -16,6 +16,11 @@ class StatsListCommandTest extends TestCase
      */
     public function overrideConfig()
     {
+        // See https://github.com/orchestral/testbench/issues/229#issuecomment-419716531
+        if (starts_with($this->app->version(), '5.7')) {
+            $this->withoutMockingConsoleOutput();
+        }
+
         config()->set('stats.paths', [
             base_path('app'),
             base_path('database'),
@@ -26,8 +31,6 @@ class StatsListCommandTest extends TestCase
     /** @test */
     public function it_works()
     {
-        $this->markTestSkipped('No longer works in Laravel 5.7');
-
         Route::get('projects', 'Wnx\LaravelStats\Tests\Stubs\Controllers\ProjectsController@index');
         Route::get('users', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@index');
 
@@ -45,8 +48,6 @@ class StatsListCommandTest extends TestCase
     /** @test */
     public function it_displays_all_headers()
     {
-        $this->markTestSkipped('No longer works in Laravel 5.7');
-
         $this->overrideConfig();
 
         $this->artisan('stats');
@@ -64,8 +65,6 @@ class StatsListCommandTest extends TestCase
     /** @test */
     public function it_returns_stats_as_json()
     {
-        $this->markTestSkipped('No longer works in Laravel 5.7');
-
         $this->overrideConfig();
 
         $this->artisan('stats', [


### PR DESCRIPTION
Update the `.travis.yml` file to test the package against supported Laravel and PHP versions.
Inspired by the [this](https://blog.tjmiller.me/verifying-laravel-version-compatibility) blog post by [TJ Miller](https://twitter.com/SIXLIV3).

- [x] Figure how to fix the skipped tests in `StatsListCommandTest.php`