### PR TITLE
Add Laravel Nova Classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ The package scans the files defined in the `paths`-array in the configuration fi
 | Event Listener | Must be registered for an Event in `EventServiceProvider` |
 | Mail | Must extend `Illuminate\Mail\Mailable` |
 | Notification | Must extend `Illuminate\Notifications\Notification` |
+| Nova Action | Must extend `Laravel\Nova\Actions\Action` |
+| Nova Filter | Must extend `Laravel\Nova\Filters\Filter` |
+| Nova Lens | Must extend `Laravel\Nova\Lenses\Lens` |
+| Nova Resource | Must extend `Laravel\Nova\Resource` |
 | Job | Must use `Illuminate\Foundation\Bus\Dispatchable`-Trait |
 | Migration | Must extend `Illuminate\Database\Migrations\Migration` |
 | Request | Must extend `Illuminate\Foundation\Http\FormRequest` |

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -3,6 +3,10 @@
 namespace Wnx\LaravelStats;
 
 use Exception;
+use Wnx\LaravelStats\Classifiers\Nova\Lens;
+use Wnx\LaravelStats\Classifiers\Nova\Filter;
+use Wnx\LaravelStats\Classifiers\Nova\Action;
+use Wnx\LaravelStats\Classifiers\Nova\Resource;
 use Wnx\LaravelStats\Classifiers\JobClassifier;
 use Wnx\LaravelStats\Classifiers\DuskClassifier;
 use Wnx\LaravelStats\Classifiers\MailClassifier;
@@ -46,6 +50,12 @@ class Classifier
         BrowserKitTestClassifier::class,
         DuskClassifier::class,
         PhpUnitClassifier::class,
+
+        // Nova Classifiers
+        Action::class,
+        Filter::class,
+        Lens::class,
+        Resource::class
     ];
 
     /**

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -4,10 +4,10 @@ namespace Wnx\LaravelStats;
 
 use Exception;
 use Wnx\LaravelStats\Classifiers\Nova\Lens;
-use Wnx\LaravelStats\Classifiers\Nova\Filter;
 use Wnx\LaravelStats\Classifiers\Nova\Action;
-use Wnx\LaravelStats\Classifiers\Nova\Resource;
+use Wnx\LaravelStats\Classifiers\Nova\Filter;
 use Wnx\LaravelStats\Classifiers\JobClassifier;
+use Wnx\LaravelStats\Classifiers\Nova\Resource;
 use Wnx\LaravelStats\Classifiers\DuskClassifier;
 use Wnx\LaravelStats\Classifiers\MailClassifier;
 use Wnx\LaravelStats\Classifiers\RuleClassifier;
@@ -55,7 +55,7 @@ class Classifier
         Action::class,
         Filter::class,
         Lens::class,
-        Resource::class
+        Resource::class,
     ];
 
     /**

--- a/src/Classifiers/Nova/Action.php
+++ b/src/Classifiers/Nova/Action.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Wnx\LaravelStats\Classifiers\Nova;
+
+use Wnx\LaravelStats\ReflectionClass;
+use Laravel\BrowserKitTesting\TestCase;
+use Wnx\LaravelStats\Contracts\Classifier;
+
+class Action implements Classifier
+{
+    public function getName()
+    {
+        return 'Nova Actions';
+    }
+
+    public function satisfies(ReflectionClass $class)
+    {
+        return class_exists(\Laravel\Nova\Actions\Action::class) && $class->isSubclassOf(\Laravel\Nova\Actions\Action::class);
+    }
+}

--- a/src/Classifiers/Nova/Action.php
+++ b/src/Classifiers/Nova/Action.php
@@ -3,7 +3,6 @@
 namespace Wnx\LaravelStats\Classifiers\Nova;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Laravel\BrowserKitTesting\TestCase;
 use Wnx\LaravelStats\Contracts\Classifier;
 
 class Action implements Classifier

--- a/src/Classifiers/Nova/Filter.php
+++ b/src/Classifiers/Nova/Filter.php
@@ -3,7 +3,6 @@
 namespace Wnx\LaravelStats\Classifiers\Nova;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Laravel\BrowserKitTesting\TestCase;
 use Wnx\LaravelStats\Contracts\Classifier;
 
 class Filter implements Classifier

--- a/src/Classifiers/Nova/Filter.php
+++ b/src/Classifiers/Nova/Filter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Wnx\LaravelStats\Classifiers\Nova;
+
+use Wnx\LaravelStats\ReflectionClass;
+use Laravel\BrowserKitTesting\TestCase;
+use Wnx\LaravelStats\Contracts\Classifier;
+
+class Filter implements Classifier
+{
+    public function getName()
+    {
+        return 'Nova Filters';
+    }
+
+    public function satisfies(ReflectionClass $class)
+    {
+        return class_exists(\Laravel\Nova\Filters\Filter::class) && $class->isSubclassOf(\Laravel\Nova\Filters\Filter::class);
+    }
+}

--- a/src/Classifiers/Nova/Lens.php
+++ b/src/Classifiers/Nova/Lens.php
@@ -3,7 +3,6 @@
 namespace Wnx\LaravelStats\Classifiers\Nova;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Laravel\BrowserKitTesting\TestCase;
 use Wnx\LaravelStats\Contracts\Classifier;
 
 class Lens implements Classifier

--- a/src/Classifiers/Nova/Lens.php
+++ b/src/Classifiers/Nova/Lens.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Wnx\LaravelStats\Classifiers\Nova;
+
+use Wnx\LaravelStats\ReflectionClass;
+use Laravel\BrowserKitTesting\TestCase;
+use Wnx\LaravelStats\Contracts\Classifier;
+
+class Lens implements Classifier
+{
+    public function getName()
+    {
+        return 'Nova Lenses';
+    }
+
+    public function satisfies(ReflectionClass $class)
+    {
+        return class_exists(\Laravel\Nova\Lenses\Lens::class) && $class->isSubclassOf(\Laravel\Nova\Lenses\Lens::class);
+    }
+}

--- a/src/Classifiers/Nova/Resource.php
+++ b/src/Classifiers/Nova/Resource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Wnx\LaravelStats\Classifiers\Nova;
+
+use Wnx\LaravelStats\ReflectionClass;
+use Laravel\BrowserKitTesting\TestCase;
+use Wnx\LaravelStats\Contracts\Classifier;
+
+class Resource implements Classifier
+{
+    public function getName()
+    {
+        return 'Nova Resources';
+    }
+
+    public function satisfies(ReflectionClass $class)
+    {
+        return class_exists(\Laravel\Nova\Resource::class) && $class->isSubclassOf(\Laravel\Nova\Resource::class);
+    }
+}

--- a/src/Classifiers/Nova/Resource.php
+++ b/src/Classifiers/Nova/Resource.php
@@ -3,7 +3,6 @@
 namespace Wnx\LaravelStats\Classifiers\Nova;
 
 use Wnx\LaravelStats\ReflectionClass;
-use Laravel\BrowserKitTesting\TestCase;
 use Wnx\LaravelStats\Contracts\Classifier;
 
 class Resource implements Classifier


### PR DESCRIPTION
As mentioned in #124, I would like to add the 4 main Nova components to the stats output.
As Nova is a payed package, I didn't add the real Nova classes to the package and I also didn't write tests to cover those new classifiers.

I plan to rewrite some of the core parts of the package over the coming weeks, to make testing the internals a bit easier and will also then add tests for the Nova classifiers.