### PR TITLE
Test against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,12 @@ matrix:
       env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
     - php: 7.2
       env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
+    - php: 7.3
+      env: LARAVEL='5.5.* 'TESTBENCH='3.5.*'
+    - php: 7.3
+      env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
+    - php: 7.3
+      env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
   fast_finish: true
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
     - php: 7.2
       env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
     - php: 7.3
-      env: LARAVEL='5.5.* 'TESTBENCH='3.5.*'
-    - php: 7.3
       env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
     - php: 7.3
       env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ matrix:
   fast_finish: true
 
 before_script:
-    - phpenv config-rm xdebug.ini
     - composer config discard-changes true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.0.0",
         "illuminate/console": "~5.5.0|~5.6.0|~5.7.0",
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0",
-        "phploc/phploc": "~4.0",
+        "phploc/phploc": "~4.0|~5.0",
         "symfony/finder": "~3.3|~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Looks like the package is broken on PHP 7.3.

> ErrorException: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? - [Travis CI](https://travis-ci.org/stefanzweifel/laravel-stats/jobs/467445599#L554)

This is caused by the [Analyser](https://github.com/sebastianbergmann/phploc/blob/1799bbc0e1e25d4e27ead845b640e8a7e480558c/src/Analyser.php#L92) class in phploc.
As this is a dependency of this package, someone would have to open a PR similar to [this one from the PHP_CodeSniffer project](https://github.com/squizlabs/PHP_CodeSniffer/pull/2086).