### PR TITLE
Refactor: Use Str-class instead of String Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ return [
 
     /*
      * Namespaces which should be ignored.
-     * Laravel Stats uses the `starts_with`-string helper, to
+     * Laravel Stats uses the `Str::startsWith()`class to
      * check if a Namespace should be ignored.
      *
      * You can use `Illuminate` to ignore the entire `Illuminate`-namespace

--- a/config/stats.php
+++ b/config/stats.php
@@ -44,7 +44,7 @@ return [
 
     /*
      * Namespaces which should be ignored.
-     * Laravel Stats uses the `starts_with`-string helper, to
+     * Laravel Stats uses the `Str::startsWith()`class to
      * check if a Namespace should be ignored.
      *
      * You can use `Illuminate` to ignore the entire `Illuminate`-namespace

--- a/src/ComponentFinder.php
+++ b/src/ComponentFinder.php
@@ -3,9 +3,9 @@
 namespace Wnx\LaravelStats;
 
 use Exception;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use SplFileInfo;
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Symfony\Component\Finder\Finder;
 use Wnx\LaravelStats\RejectionStrategies\RejectVendorClasses;
 

--- a/src/ComponentFinder.php
+++ b/src/ComponentFinder.php
@@ -3,8 +3,9 @@
 namespace Wnx\LaravelStats;
 
 use Exception;
-use SplFileInfo;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 use Wnx\LaravelStats\RejectionStrategies\RejectVendorClasses;
 
@@ -39,7 +40,7 @@ class ComponentFinder
             })
             ->reject(function ($class) {
                 foreach (config('stats.ignored_namespaces', []) as $namespace) {
-                    if (starts_with($class->getNamespaceName(), $namespace)) {
+                    if (Str::startsWith($class->getNamespaceName(), $namespace)) {
                         return true;
                     }
                 }
@@ -104,7 +105,7 @@ class ComponentFinder
     protected function isExcluded(SplFileInfo $file, Collection $excludes)
     {
         return $excludes->contains(function ($exclude) use ($file) {
-            return starts_with($file->getPathname(), $exclude);
+            return Str::startsWith($file->getPathname(), $exclude);
         });
     }
 }

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -3,6 +3,7 @@
 namespace Wnx\LaravelStats;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use ReflectionClass as NativeReflectionClass;
 
 class ReflectionClass extends NativeReflectionClass
@@ -14,7 +15,7 @@ class ReflectionClass extends NativeReflectionClass
      */
     public function isVendorProvided() : bool
     {
-        return str_contains($this->getFileName(), '/vendor/');
+        return Str::contains($this->getFileName(), '/vendor/');
     }
 
     /**

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -2,8 +2,8 @@
 
 namespace Wnx\LaravelStats;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use ReflectionClass as NativeReflectionClass;
 
 class ReflectionClass extends NativeReflectionClass

--- a/src/Statistics/CodeTestRatio.php
+++ b/src/Statistics/CodeTestRatio.php
@@ -2,6 +2,8 @@
 
 namespace Wnx\LaravelStats\Statistics;
 
+use Illuminate\Support\Str;
+
 class CodeTestRatio
 {
     protected $project;
@@ -20,7 +22,7 @@ class CodeTestRatio
     {
         return collect($this->project->components())
             ->filter(function ($_, $key) {
-                return str_contains($key, 'Test');
+                return Str::contains($key, 'Test');
             })
             ->sum('loc');
     }
@@ -29,7 +31,7 @@ class CodeTestRatio
     {
         $codeLoc = collect($this->project->components())
             ->filter(function ($_, $key) {
-                return ! str_contains($key, 'Test');
+                return ! Str::contains($key, 'Test');
             })
             ->sum('loc');
 

--- a/src/Statistics/ProjectStatistics.php
+++ b/src/Statistics/ProjectStatistics.php
@@ -2,8 +2,8 @@
 
 namespace Wnx\LaravelStats\Statistics;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 
 class ProjectStatistics
 {

--- a/src/Statistics/ProjectStatistics.php
+++ b/src/Statistics/ProjectStatistics.php
@@ -3,6 +3,7 @@
 namespace Wnx\LaravelStats\Statistics;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class ProjectStatistics
 {
@@ -85,7 +86,7 @@ class ProjectStatistics
                     return (new ComponentStatistics($name, $classes))->toArray();
                 })
                 ->sortBy(function ($component, $_) {
-                    return str_contains($component['component'], 'Test') ? 1 : $component['component'];
+                    return Str::contains($component['component'], 'Test') ? 1 : $component['component'];
                 });
         }
 

--- a/tests/Commands/StatsListCommandTest.php
+++ b/tests/Commands/StatsListCommandTest.php
@@ -2,9 +2,10 @@
 
 namespace Wnx\LaravelStats\Tests\Commands;
 
-use Wnx\LaravelStats\Tests\TestCase;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Wnx\LaravelStats\Tests\TestCase;
 
 class StatsListCommandTest extends TestCase
 {
@@ -13,7 +14,7 @@ class StatsListCommandTest extends TestCase
         parent::setUp();
 
         // See https://github.com/orchestral/testbench/issues/229#issuecomment-419716531
-        if (starts_with($this->app->version(), '5.7')) {
+        if (Str::startsWith($this->app->version(), '5.7')) {
             $this->withoutMockingConsoleOutput();
         }
 

--- a/tests/Commands/StatsListCommandTest.php
+++ b/tests/Commands/StatsListCommandTest.php
@@ -2,10 +2,10 @@
 
 namespace Wnx\LaravelStats\Tests\Commands;
 
-use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Wnx\LaravelStats\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Artisan;
 
 class StatsListCommandTest extends TestCase
 {


### PR DESCRIPTION
String and Array helpers are being deprecated in Laravel 5.8 ([Laravel News article](https://laravel-news.com/laravel-5-8-deprecates-string-and-array-helpers)).

This PR replaces the calls to the helpers with calls to the `Str`-class.