### PR TITLE
Prevent Laravel's exception throwing

### DIFF
--- a/src/Classifiers/ControllerClassifier.php
+++ b/src/Classifiers/ControllerClassifier.php
@@ -27,7 +27,11 @@ class ControllerClassifier implements Classifier
             ->map(function ($route) {
                 if (method_exists($route, 'getController')) {
                     // Laravel
-                    return get_class($route->getController());
+                    try {
+                        return get_class($route->getController());
+                    } catch (\Exception $e) {
+                        return '';
+                    }
                 }
 
                 // Lumen


### PR DESCRIPTION
An exception thrown from laravel's getController stops the collection of controller stats. This let's the stats collection process continue.