### PR TITLE
Display Total Number of Routes

### DIFF
--- a/src/Formatters/TableOutput.php
+++ b/src/Formatters/TableOutput.php
@@ -54,7 +54,7 @@ class TableOutput
 
         $metaData = array_merge(
             (new CodeTestRatio($statistics))->summary(),
-            ['No. of Routes '.resolve(NumberOfRoutes::class)->get()]
+            ['Number of Routes '.resolve(NumberOfRoutes::class)->get()]
         );
 
         $this->output->text(

--- a/src/Formatters/TableOutput.php
+++ b/src/Formatters/TableOutput.php
@@ -5,8 +5,8 @@ namespace Wnx\LaravelStats\Formatters;
 use Illuminate\Console\OutputStyle;
 use Symfony\Component\Console\Helper\Table;
 use Wnx\LaravelStats\Statistics\CodeTestRatio;
-use Symfony\Component\Console\Helper\TableStyle;
 use Wnx\LaravelStats\Statistics\NumberOfRoutes;
+use Symfony\Component\Console\Helper\TableStyle;
 use Wnx\LaravelStats\Statistics\ProjectStatistics;
 use Symfony\Component\Console\Helper\TableSeparator;
 
@@ -54,7 +54,7 @@ class TableOutput
 
         $metaData = array_merge(
             (new CodeTestRatio($statistics))->summary(),
-            ['No. of Routes ' . resolve(NumberOfRoutes::class)->get()]
+            ['No. of Routes '.resolve(NumberOfRoutes::class)->get()]
         );
 
         $this->output->text(

--- a/src/Formatters/TableOutput.php
+++ b/src/Formatters/TableOutput.php
@@ -6,6 +6,7 @@ use Illuminate\Console\OutputStyle;
 use Symfony\Component\Console\Helper\Table;
 use Wnx\LaravelStats\Statistics\CodeTestRatio;
 use Symfony\Component\Console\Helper\TableStyle;
+use Wnx\LaravelStats\Statistics\NumberOfRoutes;
 use Wnx\LaravelStats\Statistics\ProjectStatistics;
 use Symfony\Component\Console\Helper\TableSeparator;
 
@@ -51,8 +52,13 @@ class TableOutput
 
         $table->render();
 
+        $metaData = array_merge(
+            (new CodeTestRatio($statistics))->summary(),
+            ['No. of Routes ' . resolve(NumberOfRoutes::class)->get()]
+        );
+
         $this->output->text(
-            implode('    ', (new CodeTestRatio($statistics))->summary())
+            implode('    ', $metaData)
         );
     }
 }

--- a/src/Formatters/TableOutput.php
+++ b/src/Formatters/TableOutput.php
@@ -54,7 +54,7 @@ class TableOutput
 
         $metaData = array_merge(
             (new CodeTestRatio($statistics))->summary(),
-            ['Number of Routes '.resolve(NumberOfRoutes::class)->get()]
+            ['Number of Routes: '.resolve(NumberOfRoutes::class)->get()]
         );
 
         $this->output->text(

--- a/src/Statistics/JsonBuilder.php
+++ b/src/Statistics/JsonBuilder.php
@@ -47,7 +47,7 @@ class JsonBuilder
             'code_loc' => (new CodeTestRatio($this->statistics))->getCodeLoc(),
             'test_loc' => (new CodeTestRatio($this->statistics))->getTestLoc(),
             'code_to_test_ratio' => '1:'.(new CodeTestRatio($this->statistics))->getRatio(),
-            'number_of_routes' => resolve(NumberOfRoutes::class)->get()
+            'number_of_routes' => resolve(NumberOfRoutes::class)->get(),
         ];
 
         return json_encode($statsJson, JSON_PRETTY_PRINT);

--- a/src/Statistics/JsonBuilder.php
+++ b/src/Statistics/JsonBuilder.php
@@ -47,6 +47,7 @@ class JsonBuilder
             'code_loc' => (new CodeTestRatio($this->statistics))->getCodeLoc(),
             'test_loc' => (new CodeTestRatio($this->statistics))->getTestLoc(),
             'code_to_test_ratio' => '1:'.(new CodeTestRatio($this->statistics))->getRatio(),
+            'number_of_routes' => resolve(NumberOfRoutes::class)->get()
         ];
 
         return json_encode($statsJson, JSON_PRETTY_PRINT);

--- a/src/Statistics/NumberOfRoutes.php
+++ b/src/Statistics/NumberOfRoutes.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Wnx\LaravelStats\Statistics;
+
+class NumberOfRoutes
+{
+    public function get() : int
+    {
+        return rescue(function ()  {
+            return collect(app('router')->getRoutes())->count();
+        }, 0);
+    }
+}

--- a/src/Statistics/NumberOfRoutes.php
+++ b/src/Statistics/NumberOfRoutes.php
@@ -6,7 +6,7 @@ class NumberOfRoutes
 {
     public function get() : int
     {
-        return rescue(function ()  {
+        return rescue(function () {
             return collect(app('router')->getRoutes())->count();
         }, 0);
     }

--- a/tests/Commands/StatsListCommandTest.php
+++ b/tests/Commands/StatsListCommandTest.php
@@ -44,6 +44,7 @@ class StatsListCommandTest extends TestCase
         $this->assertContains('Controllers', $resultAsText);
         $this->assertContains('Other', $resultAsText);
         $this->assertContains('Total', $resultAsText);
+        $this->assertContains('Number of Routes:', $resultAsText);
     }
 
     /** @test */

--- a/tests/Statistics/NumberOfRoutesTest.php
+++ b/tests/Statistics/NumberOfRoutesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Statistics;
+
+use Illuminate\Support\Facades\Route;
+use Wnx\LaravelStats\Statistics\NumberOfRoutes;
+use Wnx\LaravelStats\Tests\TestCase;
+
+class NumberOfRoutesTest extends TestCase
+{
+    /** @test */
+    public function it_returns_0_if_no_routes_are_registered()
+    {
+        $result = resolve(NumberOfRoutes::class)->get();
+
+        $this->assertEquals(0, $result);
+    }
+
+    /** @test */
+    public function it_returns_the_number_of_registered_routes()
+    {
+        Route::get('users', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@index');
+        Route::get('users/create', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@create');
+        Route::post('users', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@store');
+        Route::get('users/{user}', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@show');
+        Route::get('users/{user}/edit', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@edit');
+        Route::patch('users/{user}', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@update');
+        Route::delete('users/{user}', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@destroy');
+
+        $result = resolve(NumberOfRoutes::class)->get();
+
+        $this->assertEquals(7, $result);
+    }
+
+    /** @test */
+    public function it_only_counts_unique_routes()
+    {
+        Route::get('users', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@index');
+        Route::get('users', 'Wnx\LaravelStats\Tests\Stubs\Controllers\UsersController@create');
+
+        $result = resolve(NumberOfRoutes::class)->get();
+
+        $this->assertEquals(1, $result);
+    }
+
+}

--- a/tests/Statistics/NumberOfRoutesTest.php
+++ b/tests/Statistics/NumberOfRoutesTest.php
@@ -2,9 +2,9 @@
 
 namespace Wnx\LaravelStats\Tests\Statistics;
 
+use Wnx\LaravelStats\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 use Wnx\LaravelStats\Statistics\NumberOfRoutes;
-use Wnx\LaravelStats\Tests\TestCase;
 
 class NumberOfRoutesTest extends TestCase
 {
@@ -42,5 +42,4 @@ class NumberOfRoutesTest extends TestCase
 
         $this->assertEquals(1, $result);
     }
-
 }


### PR DESCRIPTION
One metric currently missing from `stats` is the total number of registered routes in an application. Laravel comes with a `artisan route:list` command out of the box, but this command doesn't count the routes.

This PR calculates the number of routes and displays them in the "meta-data" row at the bottom of the table.

<img width="610" alt="Screen-Shot-2019-03-16-15-15-50 58" src="https://user-images.githubusercontent.com/1080923/54476511-8f1fc500-47fe-11e9-8371-2e4cf66e041e.png">
