### PR TITLE
[v2] Rename getName() to name() in Classifier Contract

### DIFF
--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -85,7 +85,7 @@ class Classifier
             }
 
             if ($satisfied) {
-                return $c->getName();
+                return $c->name();
             }
         }
 

--- a/src/Classifiers/BrowserKitTestClassifier.php
+++ b/src/Classifiers/BrowserKitTestClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class BrowserKitTestClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'BrowserKit Tests';
     }

--- a/src/Classifiers/CommandClassifier.php
+++ b/src/Classifiers/CommandClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class CommandClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Commands';
     }

--- a/src/Classifiers/ControllerClassifier.php
+++ b/src/Classifiers/ControllerClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class ControllerClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Controllers';
     }

--- a/src/Classifiers/DuskClassifier.php
+++ b/src/Classifiers/DuskClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class DuskClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'DuskTests';
     }

--- a/src/Classifiers/EventClassifier.php
+++ b/src/Classifiers/EventClassifier.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Events\Dispatchable;
 
 class EventClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Events';
     }

--- a/src/Classifiers/EventListenerClassifier.php
+++ b/src/Classifiers/EventListenerClassifier.php
@@ -10,7 +10,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class EventListenerClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Event Listeners';
     }

--- a/src/Classifiers/JobClassifier.php
+++ b/src/Classifiers/JobClassifier.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 
 class JobClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Jobs';
     }

--- a/src/Classifiers/MailClassifier.php
+++ b/src/Classifiers/MailClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class MailClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Mails';
     }

--- a/src/Classifiers/MiddlewareClassifier.php
+++ b/src/Classifiers/MiddlewareClassifier.php
@@ -12,7 +12,7 @@ class MiddlewareClassifier implements Classifier
 {
     protected $httpKernel;
 
-    public function getName()
+    public function name(): string
     {
         return 'Middlewares';
     }

--- a/src/Classifiers/MigrationClassifier.php
+++ b/src/Classifiers/MigrationClassifier.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Migrations\Migration;
 
 class MigrationClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Migrations';
     }

--- a/src/Classifiers/ModelClassifier.php
+++ b/src/Classifiers/ModelClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class ModelClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Models';
     }

--- a/src/Classifiers/NotificationClassifier.php
+++ b/src/Classifiers/NotificationClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class NotificationClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Notifications';
     }

--- a/src/Classifiers/Nova/Action.php
+++ b/src/Classifiers/Nova/Action.php
@@ -7,7 +7,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class Action implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Nova Actions';
     }

--- a/src/Classifiers/Nova/Filter.php
+++ b/src/Classifiers/Nova/Filter.php
@@ -7,7 +7,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class Filter implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Nova Filters';
     }

--- a/src/Classifiers/Nova/Lens.php
+++ b/src/Classifiers/Nova/Lens.php
@@ -7,7 +7,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class Lens implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Nova Lenses';
     }

--- a/src/Classifiers/Nova/Resource.php
+++ b/src/Classifiers/Nova/Resource.php
@@ -7,7 +7,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class Resource implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Nova Resources';
     }

--- a/src/Classifiers/PhpUnitClassifier.php
+++ b/src/Classifiers/PhpUnitClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class PhpUnitClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'PHPUnit Tests';
     }

--- a/src/Classifiers/PolicyClassifier.php
+++ b/src/Classifiers/PolicyClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class PolicyClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Policies';
     }

--- a/src/Classifiers/RequestClassifier.php
+++ b/src/Classifiers/RequestClassifier.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class RequestClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Requests';
     }

--- a/src/Classifiers/ResourceClassifier.php
+++ b/src/Classifiers/ResourceClassifier.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Resources\Json\Resource;
 
 class ResourceClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Resources';
     }

--- a/src/Classifiers/RuleClassifier.php
+++ b/src/Classifiers/RuleClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class RuleClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Rules';
     }

--- a/src/Classifiers/SeederClassifier.php
+++ b/src/Classifiers/SeederClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class SeederClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Seeders';
     }

--- a/src/Classifiers/ServiceProviderClassifier.php
+++ b/src/Classifiers/ServiceProviderClassifier.php
@@ -8,7 +8,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class ServiceProviderClassifier implements Classifier
 {
-    public function getName()
+    public function name(): string
     {
         return 'Service Providers';
     }

--- a/src/Contracts/Classifier.php
+++ b/src/Contracts/Classifier.php
@@ -11,7 +11,7 @@ interface Classifier
      *
      * @return string
      */
-    public function getName();
+    public function name(): string;
 
     /**
      * Determine if the given ReflectionClass should be classified

--- a/tests/Stubs/Events/DemoEvent.php
+++ b/tests/Stubs/Events/DemoEvent.php
@@ -2,7 +2,6 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs\Events;
 
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;

--- a/tests/Stubs/MyCustomComponentClassifier.php
+++ b/tests/Stubs/MyCustomComponentClassifier.php
@@ -7,7 +7,7 @@ use Wnx\LaravelStats\Contracts\Classifier;
 
 class MyCustomComponentClassifier implements Classifier
 {
-    public function getName() : string
+    public function name() : string
     {
         return 'My Custom Component';
     }


### PR DESCRIPTION
I'm currently scimming through the code, before I start working on version 2.0 off this package and I recognized this inconsistency in method names in the `Classifier`-contract. 

For 2.0, I would like to move away from the `get`-/`set`-prefixes.


**This is a breaking change which will be documented in the 1.0 > 2.0 upgrade Guide.**