### PR TITLE
[v2] Rename "LoC" to "LLoC"

### DIFF
--- a/src/Formatters/TableOutput.php
+++ b/src/Formatters/TableOutput.php
@@ -40,7 +40,7 @@ class TableOutput
         $table = new Table($this->output);
 
         $table
-            ->setHeaders(['Name', 'Classes', 'Methods', 'Methods/Class', 'Lines', 'LoC', 'LoC/Method'])
+            ->setHeaders(['Name', 'Classes', 'Methods', 'Methods/Class', 'Lines', 'LLoC', 'LLoC/Method'])
             ->setRows($statistics->components())
             ->addRow($statistics->other())
             ->addRow(new TableSeparator)

--- a/src/Statistics/CodeTestRatio.php
+++ b/src/Statistics/CodeTestRatio.php
@@ -27,7 +27,7 @@ class CodeTestRatio
             ->filter(function ($_, $key) {
                 return Str::contains($key, 'Test');
             })
-            ->sum('loc');
+            ->sum('lloc');
     }
 
     public function getCodeLoc(): int
@@ -36,7 +36,7 @@ class CodeTestRatio
             ->filter(function ($_, $key) {
                 return ! Str::contains($key, 'Test');
             })
-            ->sum('loc');
+            ->sum('lloc');
 
         if ($codeLoc == 0) {
             return 1;

--- a/src/Statistics/ComponentStatistics.php
+++ b/src/Statistics/ComponentStatistics.php
@@ -2,11 +2,11 @@
 
 namespace Wnx\LaravelStats\Statistics;
 
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Collection;
-use SebastianBergmann\PHPLOC\Analyser;
 use Wnx\LaravelStats\Component;
+use Illuminate\Support\Collection;
 use Wnx\LaravelStats\ReflectionClass;
+use SebastianBergmann\PHPLOC\Analyser;
+use Illuminate\Contracts\Support\Arrayable;
 
 class ComponentStatistics implements Arrayable
 {

--- a/src/Statistics/ComponentStatistics.php
+++ b/src/Statistics/ComponentStatistics.php
@@ -94,7 +94,7 @@ class ComponentStatistics implements Arrayable
      *
      * @return float
      */
-    public function getLinesOfCode(): float
+    public function getLogicalLinesOfCode(): float
     {
         return $this->classes
             ->map(function (ReflectionClass $class) {
@@ -110,13 +110,13 @@ class ComponentStatistics implements Arrayable
      *
      * @return float
      */
-    public function getLinesOfCodePerMethod(): float
+    public function getLogicalLinesOfCodePerMethod(): float
     {
         if ($this->getNumberOfMethods() == 0) {
             return 0;
         }
 
-        return round($this->getLinesOfCode() / $this->getNumberOfMethods(), 2);
+        return round($this->getLogicalLinesOfCode() / $this->getNumberOfMethods(), 2);
     }
 
     /**
@@ -132,8 +132,8 @@ class ComponentStatistics implements Arrayable
             'methods'           => $this->getNumberOfMethods(),
             'methods_per_class' => $this->getNumberOfMethodsPerClass(),
             'lines'             => $this->getLines(),
-            'loc'               => $this->getLinesOfCode(),
-            'loc_per_method'    => $this->getLinesOfCodePerMethod(),
+            'lloc'               => $this->getLogicalLinesOfCode(),
+            'lloc_per_method'    => $this->getLogicalLinesOfCodePerMethod(),
         ];
     }
 }

--- a/src/Statistics/JsonBuilder.php
+++ b/src/Statistics/JsonBuilder.php
@@ -27,8 +27,8 @@ class JsonBuilder
                 'methods' => $component['methods'],
                 'methods_per_class' => $component['methods_per_class'],
                 'lines' => $component['lines'],
-                'loc' => $component['loc'],
-                'loc_per_method' => $component['loc_per_method'],
+                'lloc' => $component['lloc'],
+                'lloc_per_method' => $component['lloc_per_method'],
             ];
         }
 
@@ -38,8 +38,8 @@ class JsonBuilder
             'methods' => $this->statistics->total()[2],
             'methods_per_class' => $this->statistics->total()[3],
             'lines' => $this->statistics->total()[4],
-            'loc' => $this->statistics->total()[5],
-            'loc_per_method' => $this->statistics->total()[6],
+            'lloc' => $this->statistics->total()[5],
+            'lloc_per_method' => $this->statistics->total()[6],
         ];
 
         // Build Meta Block

--- a/src/Statistics/ProjectStatistics.php
+++ b/src/Statistics/ProjectStatistics.php
@@ -68,8 +68,8 @@ class ProjectStatistics
             $stats->sum('methods'),
             round($stats->avg('methods_per_class'), 2),
             $stats->sum('lines'),
-            $stats->sum('loc'),
-            round($stats->avg('loc_per_method'), 2),
+            $stats->sum('lloc'),
+            round($stats->avg('lloc_per_method'), 2),
         ];
     }
 

--- a/tests/Statistics/ComponentStatisticsTest.php
+++ b/tests/Statistics/ComponentStatisticsTest.php
@@ -24,10 +24,10 @@ class ComponentStatisticsTest extends TestCase
         $this->assertEquals('Controllers', $result['component']);
         $this->assertEquals(2, $result['number_of_classes']);
         $this->assertEquals(62, $result['lines']);
-        $this->assertEquals(12, $result['loc']);
+        $this->assertEquals(12, $result['lloc']);
         $this->assertEquals(10, $result['methods']);
         $this->assertEquals(5, $result['methods_per_class']);
-        $this->assertEquals(1.2, $result['loc_per_method']);
+        $this->assertEquals(1.2, $result['lloc_per_method']);
     }
 
     /** @test */

--- a/tests/Statistics/ProjectStatisticsTest.php
+++ b/tests/Statistics/ProjectStatisticsTest.php
@@ -57,8 +57,8 @@ class ProjectStatisticsTest extends TestCase
         $this->assertEquals($controller['methods'], $total[2]);
         $this->assertEquals($controller['methods_per_class'], $total[3]);
         $this->assertEquals($controller['lines'], $total[4]);
-        $this->assertEquals($controller['loc'], $total[5]);
-        $this->assertEquals($controller['loc_per_method'], $total[6]);
+        $this->assertEquals($controller['lloc'], $total[5]);
+        $this->assertEquals($controller['lloc_per_method'], $total[6]);
     }
 
     /** @test */


### PR DESCRIPTION
Since the beginning the package showed the number of "Lines of Code" as "Lines" and the number of "Logical Lines of Code" as "LoC" **(not as "LLoC")**.

However, there's an important distinction between "Lines of Code" and "Logical Lines of Code" (LLoC) (See [Wikipedia](https://en.wikipedia.org/wiki/Source_lines_of_code)).

To make things clearer of what is what, the package now uses the the correct term "LLoC".

**This is a breaking change whill has to be documented in the ugprade guide.**