### PR TITLE
Drop Support for Laravel 5.6, 5.7 and PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,8 @@ dist: trusty
 
 matrix:
   include:
-    - php: 7.1
-      env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
-    - php: 7.2
-      env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
     - php: 7.2
       env: LARAVEL='5.8.*' 'TESTBENCH='3.8.*'
-    - php: 7.3
-      env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
     - php: 7.3
       env: LARAVEL='5.8.*' 'TESTBENCH='3.8.*'
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,11 @@ dist: trusty
 matrix:
   include:
     - php: 7.1
-      env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
-    - php: 7.1
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
-    - php: 7.2
-      env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
     - php: 7.2
       env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
     - php: 7.2
       env: LARAVEL='5.8.*' 'TESTBENCH='3.8.*'
-    - php: 7.3
-      env: LARAVEL='5.6.*' 'TESTBENCH='3.6.*'
     - php: 7.3
       env: LARAVEL='5.7.*' 'TESTBENCH='3.7.*'
     - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "illuminate/console": "~5.8.0",
         "illuminate/support": "~5.8.0",
         "phploc/phploc": "~4.0|~5.0",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "illuminate/console": "~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/support": "~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/console": "~5.7.0|~5.8.0",
+        "illuminate/support": "~5.7.0|~5.8.0",
         "phploc/phploc": "~4.0|~5.0",
         "symfony/finder": "~3.3|~4.0"
     },
@@ -23,7 +23,7 @@
         "laravel/browser-kit-testing": "~2.0|~3.0|~4.0|~5.0",
         "laravel/dusk": "~3.0|~4.0|~5.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "^3.6|^3.7|^3.8",
+        "orchestra/testbench": "^3.7|^3.8",
         "phpunit/phpunit": "6.*|7.*|8.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "illuminate/console": "~5.7.0|~5.8.0",
-        "illuminate/support": "~5.7.0|~5.8.0",
+        "illuminate/console": "~5.8.0",
+        "illuminate/support": "~5.8.0",
         "phploc/phploc": "~4.0|~5.0",
         "symfony/finder": "~3.3|~4.0"
     },
@@ -23,7 +23,7 @@
         "laravel/browser-kit-testing": "~2.0|~3.0|~4.0|~5.0",
         "laravel/dusk": "~3.0|~4.0|~5.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "^3.7|^3.8",
+        "orchestra/testbench": "^3.8",
         "phpunit/phpunit": "6.*|7.*|8.*"
     },
     "autoload": {

--- a/src/Console/StatsListCommand.php
+++ b/src/Console/StatsListCommand.php
@@ -7,8 +7,8 @@ use Wnx\LaravelStats\Project;
 use Illuminate\Console\Command;
 use Wnx\LaravelStats\ClassesFinder;
 use Wnx\LaravelStats\ReflectionClass;
-use Wnx\LaravelStats\Outputs\AsciiTableOutput;
 use Wnx\LaravelStats\Outputs\JsonOutput;
+use Wnx\LaravelStats\Outputs\AsciiTableOutput;
 use Wnx\LaravelStats\RejectionStrategies\RejectVendorClasses;
 
 class StatsListCommand extends Command

--- a/tests/Console/StatsListCommandTest.php
+++ b/tests/Console/StatsListCommandTest.php
@@ -14,9 +14,7 @@ class StatsListCommandTest extends TestCase
         parent::setUp();
 
         // See https://github.com/orchestral/testbench/issues/229#issuecomment-419716531
-        if ($this->isLaravel57OrNewer()) {
-            $this->withoutMockingConsoleOutput();
-        }
+        $this->withoutMockingConsoleOutput();
 
         /*
          * Override stats.path confiugration to not include `tests` folder
@@ -29,17 +27,6 @@ class StatsListCommandTest extends TestCase
             base_path('database'),
         ]);
         config()->set('stats.ignored_namespaces', []);
-    }
-
-    protected function isLaravel57OrNewer()
-    {
-        $laravelVersions = ['5.7', '5.8', '6.0'];
-
-        foreach ($laravelVersions as $version) {
-            if (Str::startsWith($this->app->version(), $version)) {
-                return true;
-            }
-        }
     }
 
     /** @test */

--- a/tests/Console/StatsListCommandTest.php
+++ b/tests/Console/StatsListCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Wnx\LaravelStats\Tests\Console;
 
-use Illuminate\Support\Str;
 use Wnx\LaravelStats\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Artisan;


### PR DESCRIPTION
This PR drops support for Laravel 5.6, 5.7 and PHP 7.1.
I've decided to drop support for these versions, as they no longer receive fixes or security fixes or will reach their end of life in the upcoming **days** or weeks.

- See Laravel Support Policy: https://laravel.com/docs/master/releases#support-policy
- See Supported Versions of PHP: https://www.php.net/supported-versions.php