### PR TITLE
Use JsonResource to identify API Resource

### DIFF
--- a/src/Classifiers/ResourceClassifier.php
+++ b/src/Classifiers/ResourceClassifier.php
@@ -4,7 +4,7 @@ namespace Wnx\LaravelStats\Classifiers;
 
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class ResourceClassifier implements Classifier
 {
@@ -15,7 +15,7 @@ class ResourceClassifier implements Classifier
 
     public function satisfies(ReflectionClass $class): bool
     {
-        return $class->isSubclassOf(Resource::class);
+        return $class->isSubclassOf(JsonResource::class);
     }
 
     public function countsTowardsApplicationCode(): bool


### PR DESCRIPTION
It seems the currenct `ResourceClassifier` doesn't itentify all Resources correctly. 
In a project I'm currently working on the Resources are not recognized and will be grouped in to "Other".

- [ ] Read more into why this change would be necessery
- [ ] Should we check if a class extends `Resource OR JsonResource`?