### PR TITLE
Fix: FQDN/Namespace for Nova DashboardClassifier

### DIFF
--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -24,6 +24,7 @@ use Wnx\LaravelStats\Classifiers\Nova\FilterClassifier;
 use Wnx\LaravelStats\Classifiers\NotificationClassifier;
 use Wnx\LaravelStats\Classifiers\Testing\DuskClassifier;
 use Wnx\LaravelStats\Classifiers\EventListenerClassifier;
+use Wnx\LaravelStats\Classifiers\Nova\DashboardClassifier;
 use Wnx\LaravelStats\Classifiers\ServiceProviderClassifier;
 use Wnx\LaravelStats\Classifiers\Testing\PhpUnitClassifier;
 use Wnx\LaravelStats\Contracts\Classifier as ClassifierContract;
@@ -55,6 +56,7 @@ class Classifier
 
         // Nova Classifiers
         ActionClassifier::class,
+        DashboardClassifier::class,
         FilterClassifier::class,
         LensClassifier::class,
         NovaResourceClassifier::class,

--- a/src/Classifiers/Nova/DashboardClassifier.php
+++ b/src/Classifiers/Nova/DashboardClassifier.php
@@ -14,7 +14,7 @@ class DashboardClassifier implements Classifier
 
     public function satisfies(ReflectionClass $class): bool
     {
-        return class_exists(\Laravel\Nova\Dashboards\Dashboard::class) && $class->isSubclassOf(\Laravel\Nova\Dashboards\Dashboard::class);
+        return class_exists(\Laravel\Nova\Dashboard::class) && $class->isSubclassOf(\Laravel\Nova\Dashboard::class);
     }
 
     public function countsTowardsApplicationCode(): bool

--- a/test-stubs-nova/Dashboard.php
+++ b/test-stubs-nova/Dashboard.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Nova\Dashboards;
+namespace Laravel\Nova;
 
 class Dashboard
 {

--- a/tests/Stubs/Nova/DemoDashboard.php
+++ b/tests/Stubs/Nova/DemoDashboard.php
@@ -2,7 +2,7 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs\Nova;
 
-use Laravel\Nova\Dashboards\Dashboard;
+use Laravel\Nova\Dashboard;
 
 class DemoDashboard extends Dashboard
 {


### PR DESCRIPTION
Building upon the work done in #158. Unlike Actions, Filters and Lenses, Nova Dashboards have the FQDN of `Laravel\Nova\Dashboard` and not `Laravel\Nova\Dashboards\Dashboard`

Closes #154.