### PR TITLE
Set `declare(strict_types=1)` everywhere

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -6,9 +6,11 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->name('*.php');
 
 return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
         'no_unused_imports' => true,
+        'declare_strict_types' => true
     ])
     ->setFinder($finder);

--- a/.php_cs
+++ b/.php_cs
@@ -2,6 +2,8 @@
 
 $finder = Symfony\Component\Finder\Finder::create()
     ->notPath('vendor')
+    ->notPath('test-stubs-nova')
+    ->notPath('tests/Stubs')
     ->in(__DIR__)
     ->name('*.php');
 

--- a/config/stats.php
+++ b/config/stats.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 return [
 

--- a/src/ClassesFinder.php
+++ b/src/ClassesFinder.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats;
 

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats;
 

--- a/src/Classifiers/CommandClassifier.php
+++ b/src/Classifiers/CommandClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/ControllerClassifier.php
+++ b/src/Classifiers/ControllerClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/EventClassifier.php
+++ b/src/Classifiers/EventClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/EventListenerClassifier.php
+++ b/src/Classifiers/EventListenerClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/JobClassifier.php
+++ b/src/Classifiers/JobClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/MailClassifier.php
+++ b/src/Classifiers/MailClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/MiddlewareClassifier.php
+++ b/src/Classifiers/MiddlewareClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/MigrationClassifier.php
+++ b/src/Classifiers/MigrationClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/ModelClassifier.php
+++ b/src/Classifiers/ModelClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/NotificationClassifier.php
+++ b/src/Classifiers/NotificationClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/Nova/ActionClassifier.php
+++ b/src/Classifiers/Nova/ActionClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers\Nova;
 

--- a/src/Classifiers/Nova/DashboardClassifier.php
+++ b/src/Classifiers/Nova/DashboardClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers\Nova;
 

--- a/src/Classifiers/Nova/FilterClassifier.php
+++ b/src/Classifiers/Nova/FilterClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers\Nova;
 

--- a/src/Classifiers/Nova/LensClassifier.php
+++ b/src/Classifiers/Nova/LensClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers\Nova;
 

--- a/src/Classifiers/Nova/ResourceClassifier.php
+++ b/src/Classifiers/Nova/ResourceClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers\Nova;
 

--- a/src/Classifiers/NullClassifier.php
+++ b/src/Classifiers/NullClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/PolicyClassifier.php
+++ b/src/Classifiers/PolicyClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/RequestClassifier.php
+++ b/src/Classifiers/RequestClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/ResourceClassifier.php
+++ b/src/Classifiers/ResourceClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/RuleClassifier.php
+++ b/src/Classifiers/RuleClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/SeederClassifier.php
+++ b/src/Classifiers/SeederClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/ServiceProviderClassifier.php
+++ b/src/Classifiers/ServiceProviderClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers;
 

--- a/src/Classifiers/Testing/BrowserKitTestClassifier.php
+++ b/src/Classifiers/Testing/BrowserKitTestClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers\Testing;
 

--- a/src/Classifiers/Testing/DuskClassifier.php
+++ b/src/Classifiers/Testing/DuskClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers\Testing;
 

--- a/src/Classifiers/Testing/PhpUnitClassifier.php
+++ b/src/Classifiers/Testing/PhpUnitClassifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Classifiers\Testing;
 

--- a/src/Console/StatsListCommand.php
+++ b/src/Console/StatsListCommand.php
@@ -60,7 +60,7 @@ class StatsListCommand extends Command
             $json = (new JsonOutput())->render(
                 $project,
                 $this->option('verbose'),
-                explode(',', $this->option('components'))
+                $this->getArrayOfComponentsToDisplay()
             );
 
             $this->output->text(json_encode($json));
@@ -68,8 +68,17 @@ class StatsListCommand extends Command
             (new AsciiTableOutput($this->output))->render(
                 $project,
                 $this->option('verbose'),
-                explode(',', $this->option('components'))
+                $this->getArrayOfComponentsToDisplay()
             );
         }
+    }
+
+    private function getArrayOfComponentsToDisplay(): array
+    {
+        if (is_null($this->option('components'))) {
+            return [];
+        }
+
+        return  explode(',', $this->option('components'));
     }
 }

--- a/src/Console/StatsListCommand.php
+++ b/src/Console/StatsListCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Console;
 

--- a/src/Contracts/Classifier.php
+++ b/src/Contracts/Classifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Contracts;
 

--- a/src/Contracts/RejectionStrategy.php
+++ b/src/Contracts/RejectionStrategy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Contracts;
 

--- a/src/Outputs/AsciiTableOutput.php
+++ b/src/Outputs/AsciiTableOutput.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Outputs;
 

--- a/src/Outputs/JsonOutput.php
+++ b/src/Outputs/JsonOutput.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Outputs;
 

--- a/src/Project.php
+++ b/src/Project.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats;
 

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats;
 

--- a/src/RejectionStrategies/RejectInternalClasses.php
+++ b/src/RejectionStrategies/RejectInternalClasses.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\RejectionStrategies;
 

--- a/src/RejectionStrategies/RejectVendorClasses.php
+++ b/src/RejectionStrategies/RejectVendorClasses.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\RejectionStrategies;
 

--- a/src/Statistics/NumberOfRoutes.php
+++ b/src/Statistics/NumberOfRoutes.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Statistics;
 

--- a/src/Statistics/ProjectStatistic.php
+++ b/src/Statistics/ProjectStatistic.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Statistics;
 

--- a/src/Statistics/ProjectStatistic.php
+++ b/src/Statistics/ProjectStatistic.php
@@ -87,7 +87,7 @@ class ProjectStatistic
         return $this->linesOfCode;
     }
 
-    public function getLogicalLinesOfCode(): int
+    public function getLogicalLinesOfCode(): float
     {
         if ($this->logicalLinesOfCode === null) {
             $this->logicalLinesOfCode = $this->project->classifiedClasses()->sum(function (ClassifiedClass $class) {
@@ -111,7 +111,7 @@ class ProjectStatistic
         return $this->logicalLinesOfCodePerMethod;
     }
 
-    public function getLogicalLinesOfCodeForApplicationCode(): int
+    public function getLogicalLinesOfCodeForApplicationCode(): float
     {
         return $this
             ->project
@@ -124,7 +124,7 @@ class ProjectStatistic
             });
     }
 
-    public function getLogicalLinesOfCodeForTestCode(): int
+    public function getLogicalLinesOfCodeForTestCode(): float
     {
         return $this
             ->project

--- a/src/StatsServiceProvider.php
+++ b/src/StatsServiceProvider.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats;
 

--- a/src/ValueObjects/ClassifiedClass.php
+++ b/src/ValueObjects/ClassifiedClass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\ValueObjects;
 

--- a/src/ValueObjects/Component.php
+++ b/src/ValueObjects/Component.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\ValueObjects;
 

--- a/src/ValueObjects/Component.php
+++ b/src/ValueObjects/Component.php
@@ -92,7 +92,7 @@ class Component
         return $this->linesOfCode;
     }
 
-    public function getLogicalLinesOfCode(): int
+    public function getLogicalLinesOfCode(): float
     {
         if ($this->logicalLinesOfCode === null) {
             $this->logicalLinesOfCode = $this->classifiedClasses->sum(function (ClassifiedClass $class) {

--- a/tests/ClassesFinderTest.php
+++ b/tests/ClassesFinderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests;
 

--- a/tests/ClassifierTest.php
+++ b/tests/ClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests;
 

--- a/tests/Classifiers/CommandClassifierTest.php
+++ b/tests/Classifiers/CommandClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/ControllerClassifierTest.php
+++ b/tests/Classifiers/ControllerClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/EventClassifierTest.php
+++ b/tests/Classifiers/EventClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/EventListenerClassifierTest.php
+++ b/tests/Classifiers/EventListenerClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/JobClassifierTest.php
+++ b/tests/Classifiers/JobClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/MailClassifierTest.php
+++ b/tests/Classifiers/MailClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/MiddlewareClassifierTest.php
+++ b/tests/Classifiers/MiddlewareClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/MigrationClassifierTest.php
+++ b/tests/Classifiers/MigrationClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/ModelClassifierTest.php
+++ b/tests/Classifiers/ModelClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/NotificationClassifierTest.php
+++ b/tests/Classifiers/NotificationClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/Nova/ActionClassifierTest.php
+++ b/tests/Classifiers/Nova/ActionClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers\Nova;
 

--- a/tests/Classifiers/Nova/DashboardClassifierTest.php
+++ b/tests/Classifiers/Nova/DashboardClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers\Nova;
 

--- a/tests/Classifiers/Nova/FilterClassifierTest.php
+++ b/tests/Classifiers/Nova/FilterClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers\Nova;
 

--- a/tests/Classifiers/Nova/LensClassifierTest.php
+++ b/tests/Classifiers/Nova/LensClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers\Nova;
 

--- a/tests/Classifiers/Nova/ResourceClassifierTest.php
+++ b/tests/Classifiers/Nova/ResourceClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers\Nova;
 

--- a/tests/Classifiers/NullClassifierTest.php
+++ b/tests/Classifiers/NullClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/PolicyClassifierTest.php
+++ b/tests/Classifiers/PolicyClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/RequestClassifierTest.php
+++ b/tests/Classifiers/RequestClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/ResourceClassifierTest.php
+++ b/tests/Classifiers/ResourceClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/RuleClassifierTest.php
+++ b/tests/Classifiers/RuleClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/SeederClassifierTest.php
+++ b/tests/Classifiers/SeederClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/ServiceProviderClassifierTest.php
+++ b/tests/Classifiers/ServiceProviderClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/Testing/BrowserKitTestCaseClassifierTest.php
+++ b/tests/Classifiers/Testing/BrowserKitTestCaseClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/Testing/DuskClassifierTest.php
+++ b/tests/Classifiers/Testing/DuskClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Classifiers/Testing/PhpUnitClassifierTest.php
+++ b/tests/Classifiers/Testing/PhpUnitClassifierTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 

--- a/tests/Console/StatsListCommandTest.php
+++ b/tests/Console/StatsListCommandTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Console;
 

--- a/tests/Outputs/JsonOutputTest.php
+++ b/tests/Outputs/JsonOutputTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Outputs;
 

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests;
 

--- a/tests/ReflectionClassTest.php
+++ b/tests/ReflectionClassTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests;
 

--- a/tests/RejectionStrategies/RejectInternalClassesTest.php
+++ b/tests/RejectionStrategies/RejectInternalClassesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\RejectionStrategies;
 

--- a/tests/RejectionStrategies/RejectVendorClassesTest.php
+++ b/tests/RejectionStrategies/RejectVendorClassesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Filters;
 

--- a/tests/Statistics/NumberOfRoutesTest.php
+++ b/tests/Statistics/NumberOfRoutesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Statistics;
 

--- a/tests/Statistics/ProjectStatisticsTest.php
+++ b/tests/Statistics/ProjectStatisticsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\Statistics;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests;
 

--- a/tests/ValueObjects/ClassifiedClassTest.php
+++ b/tests/ValueObjects/ClassifiedClassTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\ValueObjects;
 

--- a/tests/ValueObjects/ComponentTest.php
+++ b/tests/ValueObjects/ComponentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Wnx\LaravelStats\Tests\ValueObjects;
 


### PR DESCRIPTION
I'm a fan of static analysis tools. 
Setting `declare(strict_types=1)` everywhere in this package is a first step of introducing these tools to the project.