### PR TITLE
Add Observer Classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 </a>
 <a href="https://travis-ci.org/stefanzweifel/laravel-stats">
     <img src="https://travis-ci.org/stefanzweifel/laravel-stats.svg" alt="">
-</a> 
+</a>
 <a href="https://packagist.org/packages/wnx/laravel-stats">
     <img src="https://poser.pugx.org/wnx/laravel-stats/downloads" alt="">
-</a> 
+</a>
 <a href="https://scrutinizer-ci.com/g/stefanzweifel/laravel-stats/?branch=master">
     <img src="https://scrutinizer-ci.com/g/stefanzweifel/laravel-stats/badges/quality-score.png?b=master" alt="">
 </a>
@@ -111,6 +111,24 @@ return [
         'Symfony',
     ],
 
+    /*
+     * Methods which are used to satisfy a Class as an Observer.
+     */
+    'observable_events' => [
+        'retrieved',
+        'creating',
+        'created',
+        'updating',
+        'updated',
+        'saving',
+        'saved',
+        'restoring',
+        'restored',
+        'deleting',
+        'deleted',
+        'forceDeleted',
+    ],
+
 ];
 
 ```
@@ -167,6 +185,7 @@ The package scans the files defined in the `paths`-array in the configuration fi
 | Nova Resource | Must extend `Laravel\Nova\Resource` |
 | Job | Must use `Illuminate\Foundation\Bus\Dispatchable`-Trait |
 | Migration | Must extend `Illuminate\Database\Migrations\Migration` |
+| Observer | Must define on of the observable events |
 | Request | Must extend `Illuminate\Foundation\Http\FormRequest` |
 | Resource | Must extend `Illuminate\Http\Resources\Json\Resource`, `Illuminate\Http\Resources\Json\JsonResource` or `Illuminate\Http\Resources\Json\ResourceCollection` |
 | Seeder | Must extend `Illuminate\Database\Seeder` |

--- a/config/stats.php
+++ b/config/stats.php
@@ -57,4 +57,22 @@ return [
         'Symfony',
     ],
 
+    /*
+     * Methods which are used to satisfy a Class as an Observer.
+     */
+    'observable_events' => [
+        'retrieved',
+        'creating',
+        'created',
+        'updating',
+        'updated',
+        'saving',
+        'saved',
+        'restoring',
+        'restored',
+        'deleting',
+        'deleted',
+        'forceDeleted',
+    ],
+
 ];

--- a/src/Classifiers/ObserverClassifier.php
+++ b/src/Classifiers/ObserverClassifier.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Wnx\LaravelStats\Classifiers;
+
+use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+
+class ObserverClassifier implements Classifier
+{
+    public function name(): string
+    {
+        return "Observers";
+    }
+
+    public function satisfies(ReflectionClass $class): bool
+    {
+        return $class->getDefinedMethods()->contains(function($method){
+            return in_array($method->name, config('stats.observable_events'));
+        });
+    }
+
+    public function countsTowardsApplicationCode(): bool
+    {
+        return true;
+    }
+
+    public function countsTowardsTests(): bool
+    {
+        return false;
+    }
+}

--- a/src/Classifiers/ObserverClassifier.php
+++ b/src/Classifiers/ObserverClassifier.php
@@ -14,7 +14,7 @@ class ObserverClassifier implements Classifier
 
     public function satisfies(ReflectionClass $class): bool
     {
-        return $class->getDefinedMethods()->contains(function($method){
+        return $class->getDefinedMethods()->contains(function ($method) {
             return in_array($method->name, config('stats.observable_events'));
         });
     }

--- a/tests/Classifiers/ObserverClassifierTest.php
+++ b/tests/Classifiers/ObserverClassifierTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Wnx\LaravelStats\Tests\Classifiers;
+
+use Wnx\LaravelStats\Classifiers\ObserverClassifier;
+use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Tests\Stubs\Observers\DemoNonObserver;
+use Wnx\LaravelStats\Tests\TestCase;
+use Wnx\LaravelStats\Tests\Stubs\Observers\DemoObserver;
+
+class ObserverClassifierTest extends TestCase
+{
+    /** @test */
+    public function it_returns_true_if_observer_is_passed_to_satisfy_method()
+    {
+        $this->assertTrue(
+            (new ObserverClassifier)->satisfies(
+                new ReflectionClass(DemoObserver::class)
+            )
+        );
+    }
+
+    /** @test */
+    public function it_returns_false_if_non_observer_is_passed_to_satisfy_method()
+    {
+        $this->assertFalse(
+            (new ObserverClassifier)->satisfies(
+                new ReflectionClass(DemoNonObserver::class)
+            )
+        );
+    }
+}

--- a/tests/Stubs/Observers/DemoNonObserver.php
+++ b/tests/Stubs/Observers/DemoNonObserver.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs\Observers;
+
+class DemoNonObserver
+{
+
+    public function foo()
+    {
+        //
+    }
+
+}

--- a/tests/Stubs/Observers/DemoObserver.php
+++ b/tests/Stubs/Observers/DemoObserver.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs\Observers;
+
+class DemoObserver
+{
+
+    public function created()
+    {
+        //
+    }
+
+}


### PR DESCRIPTION
As already mentioned in issue #128 it is not easy to detect the Observers. 

So this PR adds a really simple approach to detect those Observers. I just look if the passed Class implements one of the default observable events. These observable events are also configurable in the laravel-stats config file. 

I think this approach could lead to false positives. 

Maybe another approach would be to detect the calls to `EloquentModel::observe` in the ServiceProvider classes. 

Happy to hear your feedback on this approach. 