### PR TITLE
Fix Plural Name of Middleware

### DIFF
--- a/src/Classifiers/MiddlewareClassifier.php
+++ b/src/Classifiers/MiddlewareClassifier.php
@@ -14,7 +14,7 @@ class MiddlewareClassifier implements Classifier
 
     public function name(): string
     {
-        return 'Middlewares';
+        return 'Middleware';
     }
 
     public function satisfies(ReflectionClass $class): bool

--- a/src/Classifiers/MiddlewareClassifier.php
+++ b/src/Classifiers/MiddlewareClassifier.php
@@ -21,29 +21,29 @@ class MiddlewareClassifier implements Classifier
     {
         $this->httpKernel = $this->getHttpKernelInstance();
 
-        $middlewares = $this->getMiddlewares();
+        $middleware = $this->getMiddleware();
 
-        if (in_array($class->getName(), $middlewares)) {
+        if (in_array($class->getName(), $middleware)) {
             return true;
         }
 
-        return collect($middlewares)
+        return collect($middleware)
             ->merge($this->getMiddlewareGroupsFromKernel())
             ->flatten()
             ->contains($class->getName());
     }
 
-    protected function getMiddlewares(): array
+    protected function getMiddleware(): array
     {
         $reflection = new ReflectionProperty($this->httpKernel, 'middleware');
         $reflection->setAccessible(true);
-        $middlewares = $reflection->getValue($this->httpKernel);
+        $middleware = $reflection->getValue($this->httpKernel);
 
         $reflection = new ReflectionProperty($this->httpKernel, 'routeMiddleware');
         $reflection->setAccessible(true);
         $routeMiddlwares = $reflection->getValue($this->httpKernel);
 
-        return array_values(array_unique(array_merge($middlewares, $routeMiddlwares)));
+        return array_values(array_unique(array_merge($middleware, $routeMiddlwares)));
     }
 
     protected function getMiddlewareGroupsFromKernel(): array

--- a/tests/ClassesFinderTest.php
+++ b/tests/ClassesFinderTest.php
@@ -55,15 +55,15 @@ class ClassesFinderTest extends TestCase
     }
 
     /** @test */
-    public function it_finds_middlewares()
+    public function it_finds_middleware()
     {
-        $this->assertTrue($this->classes->contains(\Wnx\LaravelStats\Tests\Stubs\Middlewares\DemoMiddleware::class));
+        $this->assertTrue($this->classes->contains(\Wnx\LaravelStats\Tests\Stubs\Middleware\DemoMiddleware::class));
     }
 
     /** @test */
-    public function it_finds_route_middlewares()
+    public function it_finds_route_middleware()
     {
-        $this->assertTrue($this->classes->contains(\Wnx\LaravelStats\Tests\Stubs\Middlewares\RouteMiddleware::class));
+        $this->assertTrue($this->classes->contains(\Wnx\LaravelStats\Tests\Stubs\Middleware\RouteMiddleware::class));
     }
 
     /** @test */

--- a/tests/Classifiers/MiddlewareClassifierTest.php
+++ b/tests/Classifiers/MiddlewareClassifierTest.php
@@ -6,7 +6,7 @@ use Wnx\LaravelStats\Tests\TestCase;
 use Wnx\LaravelStats\ReflectionClass;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 use Wnx\LaravelStats\Classifiers\MiddlewareClassifier;
-use Wnx\LaravelStats\Tests\Stubs\Middlewares\DemoMiddleware;
+use Wnx\LaravelStats\Tests\Stubs\Middleware\DemoMiddleware;
 
 class MiddlewareClassifierTest extends TestCase
 {

--- a/tests/Console/StatsListCommandTest.php
+++ b/tests/Console/StatsListCommandTest.php
@@ -37,7 +37,7 @@ class StatsListCommandTest extends TestCase
         $this->artisan('stats');
         $resultAsText = Artisan::output();
 
-        $this->assertStringContainsString('Middlewares', $resultAsText);
+        $this->assertStringContainsString('Middleware', $resultAsText);
         $this->assertStringContainsString('Controllers', $resultAsText);
         $this->assertStringContainsString('Other', $resultAsText);
         $this->assertStringContainsString('Total', $resultAsText);

--- a/tests/Stubs/HttpKernel.php
+++ b/tests/Stubs/HttpKernel.php
@@ -2,8 +2,8 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs;
 
-use Wnx\LaravelStats\Tests\Stubs\Middlewares\DemoMiddleware;
-use Wnx\LaravelStats\Tests\Stubs\Middlewares\RouteMiddleware;
+use Wnx\LaravelStats\Tests\Stubs\Middleware\DemoMiddleware;
+use Wnx\LaravelStats\Tests\Stubs\Middleware\RouteMiddleware;
 
 class HttpKernel extends \Illuminate\Foundation\Http\Kernel
 {

--- a/tests/Stubs/Middleware/DemoMiddleware.php
+++ b/tests/Stubs/Middleware/DemoMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wnx\LaravelStats\Tests\Stubs\Middlewares;
+namespace Wnx\LaravelStats\Tests\Stubs\Middleware;
 
 use Closure;
 

--- a/tests/Stubs/Middleware/RouteMiddleware.php
+++ b/tests/Stubs/Middleware/RouteMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wnx\LaravelStats\Tests\Stubs\Middlewares;
+namespace Wnx\LaravelStats\Tests\Stubs\Middleware;
 
 use Closure;
 


### PR DESCRIPTION
The plural of "Middleware" is not "Middlewares". It's just "Middleware". 