### PR TITLE
Add Observer Classifier

### DIFF
--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -22,6 +22,7 @@ use Wnx\LaravelStats\Classifiers\Nova\FilterClassifier;
 use Wnx\LaravelStats\Classifiers\Nova\LensClassifier;
 use Wnx\LaravelStats\Classifiers\Nova\ResourceClassifier as NovaResourceClassifier;
 use Wnx\LaravelStats\Classifiers\NullClassifier;
+use Wnx\LaravelStats\Classifiers\ObserverClassifier;
 use Wnx\LaravelStats\Classifiers\PolicyClassifier;
 use Wnx\LaravelStats\Classifiers\RequestClassifier;
 use Wnx\LaravelStats\Classifiers\ResourceClassifier;
@@ -44,6 +45,7 @@ class Classifier
         MiddlewareClassifier::class,
         EventClassifier::class,
         EventListenerClassifier::class,
+        ObserverClassifier::class,
         MailClassifier::class,
         NotificationClassifier::class,
         JobClassifier::class,

--- a/src/Classifiers/EventListenerClassifier.php
+++ b/src/Classifiers/EventListenerClassifier.php
@@ -19,12 +19,11 @@ class EventListenerClassifier implements Classifier
     {
         return collect($this->getEvents())
             ->map(function ($listeners) {
-                $subscriber = collect($listeners)->map(function (Closure $closure) {
+                return collect($listeners)->map(function (Closure $closure) {
                     return $this->getEventListener($closure);
                 })->toArray();
-
-                return $subscriber;
-            })->collapse()
+            })
+            ->collapse()
             ->unique()
             ->contains($class->getName());
     }

--- a/src/Classifiers/ObserverClassifier.php
+++ b/src/Classifiers/ObserverClassifier.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Wnx\LaravelStats\Classifiers;
+
+use Closure;
+use Illuminate\Support\Str;
+use ReflectionFunction;
+use ReflectionProperty;
+use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ObserverClassifier implements Classifier
+{
+    public function name(): string
+    {
+        return 'Observers';
+    }
+
+    public function satisfies(ReflectionClass $class): bool
+    {
+        return collect($this->getEvents())
+            ->filter(function ($listeners, $event) {
+                return Str::of($event)->startsWith('eloquent.');
+            })
+            ->map(function ($listeners) {
+                return collect($listeners)->map(function (Closure $closure) {
+                    return $this->getEventListener($closure);
+                })->toArray();
+            })
+            ->collapse()
+            ->filter(function ($eventListenerSignature) use ($class) {
+               return Str::of($eventListenerSignature)->contains($class->getName());
+            })
+            ->count() > 0;
+    }
+
+    protected function getEvents()
+    {
+        $dispatcher = app('events');
+
+        $property = new ReflectionProperty($dispatcher, 'listeners');
+        $property->setAccessible(true);
+
+        return $property->getValue($dispatcher);
+    }
+
+    protected function getEventListener(Closure $closure)
+    {
+        $reflection = new ReflectionFunction($closure);
+
+        return $reflection->getStaticVariables()['listener'];
+    }
+
+    public function countsTowardsApplicationCode(): bool
+    {
+        return true;
+    }
+
+    public function countsTowardsTests(): bool
+    {
+        return false;
+    }
+}

--- a/src/Classifiers/ObserverClassifier.php
+++ b/src/Classifiers/ObserverClassifier.php
@@ -29,8 +29,9 @@ class ObserverClassifier implements Classifier
                 })->toArray();
             })
             ->collapse()
+            ->unique()
             ->filter(function ($eventListenerSignature) use ($class) {
-               return Str::of($eventListenerSignature)->contains($class->getName());
+                return Str::of($eventListenerSignature)->contains($class->getName());
             })
             ->count() > 0;
     }

--- a/src/Classifiers/ObserverClassifier.php
+++ b/src/Classifiers/ObserverClassifier.php
@@ -8,7 +8,6 @@ use ReflectionFunction;
 use ReflectionProperty;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Contracts\Classifier;
-use Illuminate\Foundation\Events\Dispatchable;
 
 class ObserverClassifier implements Classifier
 {

--- a/tests/Classifiers/ObserverClassifierTest.php
+++ b/tests/Classifiers/ObserverClassifierTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Wnx\LaravelStats\Tests\Classifiers;
+
+use Wnx\LaravelStats\Classifiers\ObserverClassifier;
+use Wnx\LaravelStats\Tests\Stubs\Models\User;
+use Wnx\LaravelStats\Tests\Stubs\Observers\UserObserver;
+use Wnx\LaravelStats\Tests\TestCase;
+use Wnx\LaravelStats\ReflectionClass;
+
+class ObserverClassifierTest extends TestCase
+{
+
+    /** @test */
+    public function it_returns_true_if_given_class_is_a_registered_observer()
+    {
+        User::observe(UserObserver::class);
+
+        $this->assertTrue(
+            (new ObserverClassifier())->satisfies(
+                new ReflectionClass(UserObserver::class)
+            )
+        );
+    }
+}

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    //
+}

--- a/tests/Stubs/Observers/UserObserver.php
+++ b/tests/Stubs/Observers/UserObserver.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs\Observers;
+
+use Wnx\LaravelStats\Tests\Stubs\Models\User;
+
+class UserObserver
+{
+    /**
+     * Handle the user "created" event.
+     *
+     * @param  \App\User  $user
+     * @return void
+     */
+    public function created(User $user)
+    {
+        //
+    }
+
+    /**
+     * Handle the user "updated" event.
+     *
+     * @param  \App\User  $user
+     * @return void
+     */
+    public function updated(User $user)
+    {
+        //
+    }
+
+    /**
+     * Handle the user "deleted" event.
+     *
+     * @param  \App\User  $user
+     * @return void
+     */
+    public function deleted(User $user)
+    {
+        //
+    }
+
+    /**
+     * Handle the user "restored" event.
+     *
+     * @param  \App\User  $user
+     * @return void
+     */
+    public function restored(User $user)
+    {
+        //
+    }
+
+    /**
+     * Handle the user "force deleted" event.
+     *
+     * @param  \App\User  $user
+     * @return void
+     */
+    public function forceDeleted(User $user)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR adds the last (?) remaining Classifier to `stats`: [Observers](https://laravel.com/docs/master/eloquent#observers).

The Classifier works very similar to the EventListener Classifier. We resolve the Events-Dispatcher from the Laravel application, get all registered listeners, filter through the events and only keep the `eloquent.*` ones and finally check, if the registered class matches with the class which should be classified.

Closes #128 