### PR TITLE
Add Counts for Public and Non Public Methods for Classified Classes and Components

### DIFF
--- a/src/Classifiers/PolicyClassifier.php
+++ b/src/Classifiers/PolicyClassifier.php
@@ -15,7 +15,6 @@ class PolicyClassifier implements Classifier
 
     public function satisfies(ReflectionClass $class): bool
     {
-        /** @var \Illuminate\Auth\Access\Gate $gate */
         $gate = app(Gate::class);
 
         return in_array(

--- a/src/ValueObjects/ClassifiedClass.php
+++ b/src/ValueObjects/ClassifiedClass.php
@@ -33,6 +33,11 @@ class ClassifiedClass
     /**
      * @var int
      */
+    private $numberOfNonPublicMethods;
+
+    /**
+     * @var int
+     */
     private $linesOfCode;
 
     /**
@@ -75,6 +80,18 @@ class ClassifiedClass
         }
 
         return $this->numberOfPublicMethods;
+    }
+
+    public function getNumberOfNonPublicMethods(): int
+    {
+        if ($this->numberOfNonPublicMethods === null) {
+            $this->numberOfNonPublicMethods = $this->reflectionClass->getDefinedMethods()
+                ->filter(function (\ReflectionMethod $method) {
+                    return ! $method->isPublic();
+                })->count();
+        }
+
+        return $this->numberOfNonPublicMethods;
     }
 
     /**

--- a/src/ValueObjects/ClassifiedClass.php
+++ b/src/ValueObjects/ClassifiedClass.php
@@ -28,6 +28,11 @@ class ClassifiedClass
     /**
      * @var int
      */
+    private $numberOfPublicMethods;
+
+    /**
+     * @var int
+     */
     private $linesOfCode;
 
     /**
@@ -58,6 +63,18 @@ class ClassifiedClass
         }
 
         return $this->numberOfMethods;
+    }
+
+    public function getNumberOfPublicMethods(): int
+    {
+        if ($this->numberOfPublicMethods === null) {
+            $this->numberOfPublicMethods = $this->reflectionClass->getDefinedMethods()
+                ->filter(function (\ReflectionMethod $method) {
+                    return $method->isPublic();
+                })->count();
+        }
+
+        return $this->numberOfPublicMethods;
     }
 
     /**

--- a/src/ValueObjects/Component.php
+++ b/src/ValueObjects/Component.php
@@ -27,6 +27,11 @@ class Component
     private $numberOfMethods;
 
     /**
+     * @var int
+     */
+    private $numberOfPublicMethods;
+
+    /**
      * @var float
      */
     private $numberOfMethodsPerClass;
@@ -70,6 +75,17 @@ class Component
         }
 
         return $this->numberOfMethods;
+    }
+
+    public function getNumberOfPublicMethods(): int
+    {
+        if ($this->numberOfPublicMethods === null) {
+            $this->numberOfPublicMethods = $this->classifiedClasses->sum(function (ClassifiedClass $class) {
+                return $class->getNumberOfPublicMethods();
+            });
+        }
+
+        return $this->numberOfPublicMethods;
     }
 
     public function getNumberOfMethodsPerClass(): float

--- a/src/ValueObjects/Component.php
+++ b/src/ValueObjects/Component.php
@@ -32,6 +32,11 @@ class Component
     private $numberOfPublicMethods;
 
     /**
+     * @var int
+     */
+    private $numberOfNonPublicMethods;
+
+    /**
      * @var float
      */
     private $numberOfMethodsPerClass;
@@ -86,6 +91,17 @@ class Component
         }
 
         return $this->numberOfPublicMethods;
+    }
+
+    public function getNumberOfNonPublicMethods(): int
+    {
+        if ($this->numberOfNonPublicMethods === null) {
+            $this->numberOfNonPublicMethods = $this->classifiedClasses->sum(function (ClassifiedClass  $class) {
+                return $class->getNumberOfNonPublicMethods();
+            });
+        }
+
+        return $this->numberOfNonPublicMethods;
     }
 
     public function getNumberOfMethodsPerClass(): float

--- a/tests/Console/StatsListCommandTest.php
+++ b/tests/Console/StatsListCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Wnx\LaravelStats\Tests\Console;
 
-use Wnx\LaravelStats\Tests\Stubs\Mails\DemoMail;
 use Wnx\LaravelStats\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Artisan;

--- a/tests/Stubs/Controllers/UsersController.php
+++ b/tests/Stubs/Controllers/UsersController.php
@@ -38,4 +38,14 @@ class UsersController extends Controller
     {
         return [];
     }
+
+    private function thePrivateMethod()
+    {
+        //
+    }
+
+    protected function theProtectedMethod()
+    {
+        //
+    }
 }

--- a/tests/ValueObjects/ClassifiedClassTest.php
+++ b/tests/ValueObjects/ClassifiedClassTest.php
@@ -22,7 +22,7 @@ class ClassifiedClassTest extends TestCase
     public function it_returns_number_of_methods_for_a_classified_class()
     {
         $this->assertEquals(
-            7,
+            9,
             $this->getClassifiedClass()->getNumberOfMethods()
         );
     }
@@ -49,7 +49,7 @@ class ClassifiedClassTest extends TestCase
     public function it_returns_number_of_lines_of_code_for_a_classified_class()
     {
         $this->assertEquals(
-            41,
+            51,
             $this->getClassifiedClass()->getLines()
         );
     }
@@ -67,7 +67,7 @@ class ClassifiedClassTest extends TestCase
     public function it_returns_average_number_of_logical_lines_of_code_per_method_for_a_classified_class()
     {
         $this->assertEquals(
-            1.0,
+            0.78,
             $this->getClassifiedClass()->getLogicalLinesOfCodePerMethod()
         );
     }

--- a/tests/ValueObjects/ClassifiedClassTest.php
+++ b/tests/ValueObjects/ClassifiedClassTest.php
@@ -28,6 +28,24 @@ class ClassifiedClassTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_number_of_public_methods_for_a_classified_class()
+    {
+        $this->assertEquals(
+            7,
+            $this->getClassifiedClass()->getNumberOfPublicMethods()
+        );
+    }
+
+    /** @test */
+    public function it_returns_number_of_non_public_methods_for_a_classified_class()
+    {
+        $this->assertEquals(
+            2,
+            $this->getClassifiedClass()->getNumberOfNonPublicMethods()
+        );
+    }
+
+    /** @test */
     public function it_returns_number_of_lines_of_code_for_a_classified_class()
     {
         $this->assertEquals(

--- a/tests/ValueObjects/ComponentTest.php
+++ b/tests/ValueObjects/ComponentTest.php
@@ -44,7 +44,7 @@ class ComponentTest extends TestCase
     {
         $component = $this->getTestComponent();
 
-        $this->assertEquals(13, $component->getNumberOfMethods());
+        $this->assertEquals(15, $component->getNumberOfMethods());
     }
 
     /** @test */
@@ -68,7 +68,7 @@ class ComponentTest extends TestCase
     {
         $component = $this->getTestComponent();
 
-        $this->assertEquals(4.33, $component->getNumberOfMethodsPerClass());
+        $this->assertEquals(5, $component->getNumberOfMethodsPerClass());
     }
 
     /** @test */
@@ -76,7 +76,7 @@ class ComponentTest extends TestCase
     {
         $component = $this->getTestComponent();
 
-        $this->assertEquals(103, $component->getLinesOfCode());
+        $this->assertEquals(113, $component->getLinesOfCode());
     }
 
     /** @test */
@@ -92,6 +92,6 @@ class ComponentTest extends TestCase
     {
         $component = $this->getTestComponent();
 
-        $this->assertEquals(0.85, $component->getLogicalLinesOfCodePerMethod());
+        $this->assertEquals(0.73, $component->getLogicalLinesOfCodePerMethod());
     }
 }

--- a/tests/ValueObjects/ComponentTest.php
+++ b/tests/ValueObjects/ComponentTest.php
@@ -48,6 +48,22 @@ class ComponentTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_number_of_public_methods_for_all_classes_within_a_component()
+    {
+        $component = $this->getTestComponent();
+
+        $this->assertEquals(12, $component->getNumberOfPublicMethods());
+    }
+
+    /** @test */
+    public function it_returns_number_of_non_public_methods_for_all_classes_within_a_component()
+    {
+        $component = $this->getTestComponent();
+
+        $this->assertEquals(3, $component->getNumberOfNonPublicMethods());
+    }
+
+    /** @test */
     public function it_returns_average_number_of_methods_per_class_for_all_classes_within_a_component()
     {
         $component = $this->getTestComponent();


### PR DESCRIPTION
This PR adds 2 new methods to a `ClassifiedClass` and to `Component`:

- `getNumberOfPublicMethods()`
- `getNumberOfNonPublicMethods()`

The methods are currently not in use. 
I plan to add them "somehow" to the statistics ASCII table.

Would also be cool to add them to the shared metrics in #178. I think adding a metric to show the distribution between public and non-public methods in controllers could be insightful.