### PR TITLE
Add Laravel 8 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,13 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4]
-        laravel: [7.*]
+        laravel: [7.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 7.*
             testbench: 5.*
+          - laravel: 8.*
+            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "mockery/mockery": "^1.1",
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
         "phpunit/phpunit": "8.* || 9.*",
-        "psalm/plugin-laravel": "^1.3",
         "vimeo/psalm": "^3.12"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,17 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "illuminate/console": "^7.0",
-        "illuminate/support": "^7.0",
+        "illuminate/console": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0",
         "phploc/phploc": "~6.0",
         "symfony/finder": "~5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",
-        "laravel/browser-kit-testing": "~6.0",
-        "laravel/dusk": "~5.0",
+        "laravel/browser-kit-testing": "~6.0|~7.0",
+        "laravel/dusk": "~5.0|~6.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "^5.0",
+        "orchestra/testbench": "^5.0|^6.0",
         "phpunit/phpunit": "9.*",
         "psalm/plugin-laravel": "^1.3",
         "vimeo/psalm": "^3.12"

--- a/src/Classifiers/DatabaseFactoryClassifier.php
+++ b/src/Classifiers/DatabaseFactoryClassifier.php
@@ -15,6 +15,10 @@ class DatabaseFactoryClassifier implements Classifier
 
     public function satisfies(ReflectionClass $class): bool
     {
+        if ((float) app()->version() < 8) {
+            return false;
+        }
+
         return $class->isSubclassOf(Factory::class);
     }
 

--- a/src/Classifiers/DatabaseFactoryClassifier.php
+++ b/src/Classifiers/DatabaseFactoryClassifier.php
@@ -2,9 +2,9 @@
 
 namespace Wnx\LaravelStats\Classifiers;
 
-use Illuminate\Database\Eloquent\Factory;
-use Wnx\LaravelStats\ReflectionClass;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Wnx\LaravelStats\Contracts\Classifier;
+use Wnx\LaravelStats\ReflectionClass;
 
 class DatabaseFactoryClassifier implements Classifier
 {

--- a/tests/ClassesFinderTest.php
+++ b/tests/ClassesFinderTest.php
@@ -20,6 +20,10 @@ class ClassesFinderTest extends TestCase
             $excludedFiles[] = __DIR__.'/../tests/Stubs/BladeComponents/StubBladeComponent.php';
         }
 
+        if ($this->getLaravelVersion() < 8) {
+            $excludedFiles[] = __DIR__.'/../tests/Stubs/DatabaseFactories/StubUserDatabaseFactory.php';
+        }
+
         config()->set('stats', [
             'paths' => [
                 __DIR__.'/../tests/Stubs',

--- a/tests/Classifiers/DatabaseFactoryClassifierTest.php
+++ b/tests/Classifiers/DatabaseFactoryClassifierTest.php
@@ -12,6 +12,10 @@ class DatabaseFactoryClassifierTest extends TestCase
     /** @test */
     public function it_returns_true_if_database_factory_is_passed_to_satisfy_method()
     {
+        if ($this->getLaravelVersion() < 8) {
+            $this->markTestSkipped("Can't run test on older Laravel Versions");
+        }
+
         $this->assertTrue(
             (new DatabaseFactoryClassifier())->satisfies(
                 new ReflectionClass(StubUserDatabaseFactory::class)
@@ -22,12 +26,20 @@ class DatabaseFactoryClassifierTest extends TestCase
     /** @test */
     public function it_does_not_count_database_factory_againt_app_code()
     {
+        if ($this->getLaravelVersion() < 8) {
+            $this->markTestSkipped("Can't run test on older Laravel Versions");
+        }
+
         $this->assertFalse((new DatabaseFactoryClassifier())->countsTowardsApplicationCode());
     }
 
     /** @test */
     public function it_does_not_count_database_factor_against_test_code()
     {
+        if ($this->getLaravelVersion() < 8) {
+            $this->markTestSkipped("Can't run test on older Laravel Versions");
+        }
+
         $this->assertFalse((new DatabaseFactoryClassifier())->countsTowardsTests());
     }
 }

--- a/tests/Stubs/DatabaseFactories/StubUserDatabaseFactory.php
+++ b/tests/Stubs/DatabaseFactories/StubUserDatabaseFactory.php
@@ -2,7 +2,7 @@
 
 namespace Wnx\LaravelStats\Tests\Stubs\DatabaseFactories;
 
-use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Wnx\LaravelStats\Tests\Stubs\Models\User;
 
 class StubUserDatabaseFactory extends Factory


### PR DESCRIPTION
This PR updates version constraints to support Laravel 8 which will be release on September 8th 2020.

I will give my best to tag a stable release of laravel-stats as soon as possible. However, the package depends on quite a lot of packages which all need to support Laravel 8 too. 
A stable release might be delayed by a couple of hours or days!

## TODOs

- [x] On Release day: Clone PR, Run `composer upgrade` and run tests
