### PR TITLE
Add Database Factory Classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The package scans the files defined in the `paths`-array in the configuration fi
 | ServiceProvider | Must extend `Illuminate\Support\ServiceProvider` |
 | Blade Components | Must extend `Illuminate\View\Component` |
 | Custom Casts | Must implement `Illuminate\Contracts\Database\Eloquent\CastsAttributes` or `Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes` |
+| Database Factory | Must extend `Illuminate\Database\Eloquent\Factory` |
 | Dusk Tests | Must extend `Laravel\Dusk\TestCase` |
 | BrowserKit Test | Must extend `Laravel\BrowserKitTesting\TestCase` |
 | PHPUnit Test | Must extend `PHPUnit\Framework\TestCase` |

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -8,6 +8,7 @@ use Wnx\LaravelStats\Classifiers\BladeComponentClassifier;
 use Wnx\LaravelStats\Classifiers\CommandClassifier;
 use Wnx\LaravelStats\Classifiers\ControllerClassifier;
 use Wnx\LaravelStats\Classifiers\CustomCastClassifier;
+use Wnx\LaravelStats\Classifiers\DatabaseFactoryClassifier;
 use Wnx\LaravelStats\Classifiers\EventClassifier;
 use Wnx\LaravelStats\Classifiers\EventListenerClassifier;
 use Wnx\LaravelStats\Classifiers\JobClassifier;
@@ -56,6 +57,7 @@ class Classifier
         ServiceProviderClassifier::class,
         BladeComponentClassifier::class,
         CustomCastClassifier::class,
+        DatabaseFactoryClassifier::class,
         BrowserKitTestClassifier::class,
         DuskClassifier::class,
         PhpUnitClassifier::class,

--- a/src/Classifiers/DatabaseFactoryClassifier.php
+++ b/src/Classifiers/DatabaseFactoryClassifier.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Wnx\LaravelStats\Classifiers;
+
+use Illuminate\Database\Eloquent\Factory;
+use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Contracts\Classifier;
+
+class DatabaseFactoryClassifier implements Classifier
+{
+    public function name(): string
+    {
+        return 'Database Factories';
+    }
+
+    public function satisfies(ReflectionClass $class): bool
+    {
+        return $class->isSubclassOf(Factory::class);
+    }
+
+    public function countsTowardsApplicationCode(): bool
+    {
+        return false;
+    }
+
+    public function countsTowardsTests(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Classifiers/DatabaseFactoryClassifierTest.php
+++ b/tests/Classifiers/DatabaseFactoryClassifierTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Wnx\LaravelStats\Tests\Classifiers;
+
+use Wnx\LaravelStats\Tests\TestCase;
+use Wnx\LaravelStats\ReflectionClass;
+use Wnx\LaravelStats\Classifiers\DatabaseFactoryClassifier;
+use Wnx\LaravelStats\Tests\Stubs\DatabaseFactories\StubUserDatabaseFactory;
+
+class DatabaseFactoryClassifierTest extends TestCase
+{
+    /** @test */
+    public function it_returns_true_if_database_factory_is_passed_to_satisfy_method()
+    {
+        $this->assertTrue(
+            (new DatabaseFactoryClassifier())->satisfies(
+                new ReflectionClass(StubUserDatabaseFactory::class)
+            )
+        );
+    }
+
+    /** @test */
+    public function it_does_not_count_database_factory_againt_app_code()
+    {
+        $this->assertFalse((new DatabaseFactoryClassifier())->countsTowardsApplicationCode());
+    }
+
+    /** @test */
+    public function it_does_not_count_database_factor_against_test_code()
+    {
+        $this->assertFalse((new DatabaseFactoryClassifier())->countsTowardsTests());
+    }
+}

--- a/tests/ShareableMetrics/AllMetricPayloadKeysTest.php
+++ b/tests/ShareableMetrics/AllMetricPayloadKeysTest.php
@@ -19,5 +19,6 @@ class AllMetricPayloadKeysTest extends TestCase
         $this->assertContains('models_mass_assignment', $result);
         $this->assertContains('controllers_lloc_per_method', $result);
         $this->assertContains('nova_lenses_methods', $result);
+        $this->assertContains('database_factories_lloc', $result);
     }
 }

--- a/tests/Stubs/DatabaseFactories/StubUserDatabaseFactory.php
+++ b/tests/Stubs/DatabaseFactories/StubUserDatabaseFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Wnx\LaravelStats\Tests\Stubs\DatabaseFactories;
+
+use Illuminate\Database\Eloquent\Factory;
+use Wnx\LaravelStats\Tests\Stubs\Models\User;
+
+class StubUserDatabaseFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+            'email' => $this->faker->unique()->safeEmail,
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+}


### PR DESCRIPTION
Adds support for the new Database Factories coming in Laravel 8: https://laravel.com/docs/8.x/database-testing#writing-factories

Closes #181 