### PR TITLE
Upgrade stefanzweifel/laravel-stats-phploc to ^7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-json": "*",
         "illuminate/console": "^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
-        "stefanzweifel/laravel-stats-phploc": "^7.1",
+        "stefanzweifel/laravel-stats-phploc": "^6.1 || ^7.1",
         "symfony/finder": "^4.3 || ^5.0",
         "symfony/process": "^4.3 || ^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-json": "*",
         "illuminate/console": "^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
-        "stefanzweifel/laravel-stats-phploc": "^6.1",
+        "stefanzweifel/laravel-stats-phploc": "^7.1",
         "symfony/finder": "^4.3 || ^5.0",
         "symfony/process": "^4.3 || ^5.0"
     },


### PR DESCRIPTION
Update the `stefanzweifel/laravel-stats-phploc` depdendency to a new major version. 
`stefanzweifel/laravel-stats-phploc` is a fork of [`sebastianbergmann/phploc`](https://github.com/sebastianbergmann/phploc). It recently has been updates with the latest changes from the original repository.

This closes #184. 