### PR TITLE
Add Support for PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4]
+        php: [7.3, 7.4, 8.0]
         laravel: [6.*, 7.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extension: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           ini-values: pcov.directory=src
           coverage: pcov
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "symfony/process": "^4.3 || ^5.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.15",
         "laravel/browser-kit-testing": "~5.0 || ~6.0 || ~7.0",
         "laravel/dusk": "~5.0 || ~6.0",
         "mockery/mockery": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "illuminate/console": "^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=7.3.0 || ^8.0",
         "ext-json": "*",
         "illuminate/console": "^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",


### PR DESCRIPTION
This PR updates the package to run on PHP 8.

The build currently fails, as `laravel/dusk` is not yet compatible with PHP 8. Dusk in turn is waiting on [`php-webdriver`](https://github.com/php-webdriver/php-webdriver/) to be updated to work with PHP 8. (https://github.com/laravel/dusk/pull/833)

I've also removed `friendsofphp/php-cs-fixer` as a dependency. (See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4702#issuecomment-719545818)

## TODOs

- [ ] ~~Update `laravel/dusk`-requirement (?)~~
- [ ] ~~Update Matrix in `test.yml` so that only Laravel Version which support PHP 8 are actually tested against PHP 8~~