### PR TITLE
Add Support for SSH and HTTPS Connections

### DIFF
--- a/src/ShareableMetrics/ProjectName.php
+++ b/src/ShareableMetrics/ProjectName.php
@@ -34,11 +34,23 @@ class ProjectName
             return null;
         }
 
-        $remoteUrl = parse_url(trim($process->getOutput()));
+        $remoteUrl = trim($process->getOutput());
 
+        // HTTPS Connections
+        if (Str::startsWith($remoteUrl, 'http')) {
+            $remoteUrl = parse_url($remoteUrl);
+            $remoteUrl = Str::replaceLast('.git', '', $remoteUrl['path']);
+
+            return Str::replaceFirst('/', '', $remoteUrl);
+        }
+
+        // SSH Connections
+        $remoteUrl = parse_url($remoteUrl);
         $remoteUrl = Str::replaceLast('.git', '', $remoteUrl['path']);
 
-        return Str::replaceFirst('/', '', $remoteUrl);
+        [$_, $remoteUrl] = explode(':', $remoteUrl);
+
+        return $remoteUrl;
     }
 
     protected function getGitBinaryPath(): ?string


### PR DESCRIPTION
This PR updates `ProjectName` to parse the correct project name from both SSH and HTTPS git remote connections.

For example:

```shell
https://github.com/stefanzweifel/laravel-stats.git #https
git@github.com:stefanzweifel/laravel-stats.git #ssh
```