### PR TITLE
Add rector/rector to automatically refactor code in the future

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
         "phpunit/phpunit": "8.* || 9.*",
         "psalm/plugin-laravel": "^1.4",
+        "rector/rector": "^0.9",
         "vimeo/psalm": "^4.0"
     },
     "autoload": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::SETS, [
+        SetList::CODE_QUALITY,
+        SetList::DEAD_DOC_BLOCK,
+    ]);
+
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_73);
+
+    $services = $containerConfigurator->services();
+    $services->set(TypedPropertyRector::class);
+};

--- a/src/ClassesFinder.php
+++ b/src/ClassesFinder.php
@@ -14,8 +14,6 @@ class ClassesFinder
      * Find PHP Files on filesystem and require them.
      * We need to use ob_* functions to ensure that
      * loaded files do not output anything.
-     *
-     * @return \Illuminate\Support\Collection
      */
     public function findAndLoadClasses(): Collection
     {
@@ -36,8 +34,6 @@ class ClassesFinder
 
     /**
      * Find PHP Files which should be analyzed.
-     *
-     * @return \Illuminate\Support\Collection
      */
     protected function findFilesInProjectPath(): Collection
     {
@@ -56,10 +52,7 @@ class ClassesFinder
     /**
      * Determine if a file has been defined in the exclude configuration.
      *
-     * @param  SplFileInfo $file
-     * @param  \Illuminate\Support\Collection  $excludes
      *
-     * @return bool
      */
     protected function isExcluded(SplFileInfo $file, Collection $excludes): bool
     {

--- a/src/Classifier.php
+++ b/src/Classifier.php
@@ -109,9 +109,7 @@ class Classifier
     /**
      * Check if a class implements our Classifier Contract.
      *
-     * @param  string $classifier
      *
-     * @return bool
      */
     protected function implementsContract(string $classifier): bool
     {

--- a/src/Classifiers/ResourceClassifier.php
+++ b/src/Classifiers/ResourceClassifier.php
@@ -19,12 +19,7 @@ class ResourceClassifier implements Classifier
         if ($class->isSubclassOf(JsonResource::class)) {
             return true;
         }
-
-        if ($class->isSubclassOf(ResourceCollection::class)) {
-            return true;
-        }
-
-        return false;
+        return $class->isSubclassOf(ResourceCollection::class);
     }
 
     public function countsTowardsApplicationCode(): bool

--- a/src/Contracts/Classifier.php
+++ b/src/Contracts/Classifier.php
@@ -8,8 +8,6 @@ interface Classifier
 {
     /**
      * Component Name displayed in the results.
-     *
-     * @return string
      */
     public function name(): string;
 
@@ -17,25 +15,19 @@ interface Classifier
      * Determine if the given ReflectionClass should be classified
      * as the component the Classifier Class represents.
      *
-     * @param \Wnx\LaravelStats\ReflectionClass $class
      *
-     * @return bool
      */
     public function satisfies(ReflectionClass $class): bool;
 
     /**
      * Determine if the lines of code of the component should count towards
      * the total number of lines of code of the application.
-     *
-     * @return bool
      */
     public function countsTowardsApplicationCode(): bool;
 
     /**
      * Determine if the lines of code of the component should count towards
      * the total number of lines of code of the test suite.
-     *
-     * @return bool
      */
     public function countsTowardsTests(): bool;
 }

--- a/src/Contracts/RejectionStrategy.php
+++ b/src/Contracts/RejectionStrategy.php
@@ -11,9 +11,7 @@ interface RejectionStrategy
      * A rejected Class does not count to the
      * project statistics.
      *
-     * @param \Wnx\LaravelStats\ReflectionClass $class
      *
-     * @return bool
      */
     public function shouldClassBeRejected(ReflectionClass $class): bool;
 }

--- a/src/Outputs/AsciiTableOutput.php
+++ b/src/Outputs/AsciiTableOutput.php
@@ -32,8 +32,6 @@ class AsciiTableOutput
 
     /**
      * Create new instance of JsonOutput.
-     *
-     * @param \Illuminate\Console\OutputStyle $output
      */
     public function __construct(OutputStyle $output)
     {
@@ -84,7 +82,7 @@ class AsciiTableOutput
 
             // If the verbose option has been passed, also display each
             // classified Class in it's own row
-            if ($this->isVerbose === true) {
+            if ($this->isVerbose) {
                 foreach ($classifiedClasses as $classifiedClass) {
                     $this->addClassifiedClassTableRow($table, $classifiedClass);
                 }

--- a/src/Outputs/JsonOutput.php
+++ b/src/Outputs/JsonOutput.php
@@ -23,7 +23,7 @@ class JsonOutput
         foreach ($groupedByComponent as $componentName => $classifiedClasses) {
             $singleComponent = $this->getStatisticsArrayComponent($componentName, $classifiedClasses);
 
-            if ($isVerbose === true) {
+            if ($isVerbose) {
                 $arrayOfClasses = [];
 
                 foreach ($classifiedClasses as $classifiedClass) {

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -11,8 +11,6 @@ class ReflectionClass extends NativeReflectionClass
 {
     /**
      * Determine if class is located in the vendor directory.
-     *
-     * @return bool
      */
     public function isVendorProvided(): bool
     {
@@ -22,9 +20,7 @@ class ReflectionClass extends NativeReflectionClass
     /**
      * Determine whether the class uses the given trait.
      *
-     * @param  string $name
      *
-     * @return bool
      */
     public function usesTrait(string $name): bool
     {
@@ -37,14 +33,12 @@ class ReflectionClass extends NativeReflectionClass
     /**
      * Return a collection of methods defined on the given class.
      * This ignores methods defined in parent class, traits etc.
-     *
-     * @return \Illuminate\Support\Collection
      */
     public function getDefinedMethods(): Collection
     {
         return collect($this->getMethods())
             ->filter(function (ReflectionMethod $method) {
-                return $method->getFileName() == $this->getFileName();
+                return $method->getFileName() === $this->getFileName();
             });
     }
 }

--- a/src/ShareableMetrics/Metrics/ComposerPsr4Sources.php
+++ b/src/ShareableMetrics/Metrics/ComposerPsr4Sources.php
@@ -17,8 +17,6 @@ class ComposerPsr4Sources extends Metric implements CollectableMetric
     {
         $composerJson = json_decode(File::get(base_path('composer.json')), true);
 
-        $psr4 = Arr::get($composerJson, 'autoload.psr-4', []);
-
-        return $psr4;
+        return Arr::get($composerJson, 'autoload.psr-4', []);
     }
 }

--- a/src/ShareableMetrics/ProjectName.php
+++ b/src/ShareableMetrics/ProjectName.php
@@ -30,7 +30,7 @@ class ProjectName
         $process = Process::fromShellCommandline("{$gitPath} config --get remote.origin.url");
         $process->run();
 
-        if ($process->isSuccessful() === false) {
+        if (!$process->isSuccessful()) {
             return null;
         }
 
@@ -58,7 +58,7 @@ class ProjectName
         $process = Process::fromShellCommandline('which git');
         $process->run();
 
-        if ($process->isSuccessful() === false) {
+        if (!$process->isSuccessful()) {
             return null;
         }
 

--- a/src/ValueObjects/ClassifiedClass.php
+++ b/src/ValueObjects/ClassifiedClass.php
@@ -58,8 +58,6 @@ class ClassifiedClass
 
     /**
      * Return the total number of Methods declared in all declared classes.
-     *
-     * @return int
      */
     public function getNumberOfMethods(): int
     {
@@ -96,8 +94,6 @@ class ClassifiedClass
 
     /**
      * Return the total number of lines.
-     *
-     * @return int
      */
     public function getLines(): int
     {
@@ -111,8 +107,6 @@ class ClassifiedClass
 
     /**
      * Return the total number of lines of code.
-     *
-     * @return float
      */
     public function getLogicalLinesOfCode(): float
     {
@@ -126,8 +120,6 @@ class ClassifiedClass
 
     /**
      * Return the average number of lines of code per method.
-     *
-     * @return float
      */
     public function getLogicalLinesOfCodePerMethod(): float
     {


### PR DESCRIPTION
This PR adds[`rector`](https://github.com/rectorphp/rector) to laravel-stats.
Through `rector` we can automatically upgrade the code base to use new PHP features.

