### PR TITLE
Fix: Make ObserverClassifier work with Closure Based Event Listeners

### DIFF
--- a/src/Classifiers/ObserverClassifier.php
+++ b/src/Classifiers/ObserverClassifier.php
@@ -29,7 +29,10 @@ class ObserverClassifier implements Classifier
             })
             ->collapse()
             ->unique()
-            ->filter(function ($eventListenerSignature) use ($class) {
+            ->filter(function ($eventListener) {
+                return is_string($eventListener);
+            })
+            ->filter(function (string $eventListenerSignature) use ($class) {
                 return Str::contains($eventListenerSignature, $class->getName());
             })
             ->count() > 0;

--- a/tests/ShareableMetrics/Metrics/CodeTestRatioTest.php
+++ b/tests/ShareableMetrics/Metrics/CodeTestRatioTest.php
@@ -33,6 +33,6 @@ class CodeTestRatioTest extends TestCase
 
         $metric = new CodeTestRatio($project);
 
-        $this->assertEquals(0.8, $metric->value());
+        $this->assertEquals(0.6, $metric->value());
     }
 }

--- a/tests/ShareableMetrics/Metrics/ProjectLinesOfCodeTest.php
+++ b/tests/ShareableMetrics/Metrics/ProjectLinesOfCodeTest.php
@@ -33,6 +33,6 @@ class ProjectLinesOfCodeTest extends TestCase
 
         $metric = new ProjectLinesOfCode($project);
 
-        $this->assertEquals(132, $metric->value());
+        $this->assertEquals(139, $metric->value());
     }
 }

--- a/tests/ShareableMetrics/Metrics/ProjectLogicalLinesOfCodeTest.php
+++ b/tests/ShareableMetrics/Metrics/ProjectLogicalLinesOfCodeTest.php
@@ -33,6 +33,6 @@ class ProjectLogicalLinesOfCodeTest extends TestCase
 
         $metric = new ProjectLogicalLinesOfCode($project);
 
-        $this->assertEquals(12.0, $metric->value());
+        $this->assertEquals(13.0, $metric->value());
     }
 }

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -10,6 +10,13 @@ class User extends Model
 {
     protected $fillable = [];
 
+    protected static function booted()
+    {
+        static::created(function ($user) {
+            // Closure Event Listener
+        });
+    }
+
     public function projects(): HasMany
     {
         return $this->hasMany(Project::class);


### PR DESCRIPTION
Fixes #192 by checking that the registered event listeners of type string. 
Event listeners which are registered as closures in a Models boot method are discarded.