### PR TITLE
Exclude Swoole Namespace from being included by Stats by default

### DIFF
--- a/config/stats.php
+++ b/config/stats.php
@@ -54,6 +54,7 @@ return [
         'Wnx\LaravelStats',
         'Illuminate',
         'Symfony',
+        'Swoole',
     ],
 
 ];


### PR DESCRIPTION
Closes #195 by excluding the Swoole Namespace.