### PR TITLE
Drop Support for Laravel 6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,9 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0]
-        laravel: [6.*, 7.*, 8.*]
+        laravel: [7.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 6.*
-            testbench: 4.*
           - laravel: 7.*
             testbench: 5.*
           - laravel: 8.*

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-json": "*",
         "illuminate/console": "^7.0 || ^8.0",
         "illuminate/support": "^7.0 || ^8.0",
-        "stefanzweifel/laravel-stats-phploc": "^6.1 || ^7.1",
+        "phploc/phploc": "^7.0",
         "symfony/finder": "^4.3 || ^5.0",
         "symfony/process": "^4.3 || ^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "illuminate/console": "^6.0 || ^7.0 || ^8.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0",
+        "illuminate/console": "^7.0 || ^8.0",
+        "illuminate/support": "^7.0 || ^8.0",
         "stefanzweifel/laravel-stats-phploc": "^6.1 || ^7.1",
         "symfony/finder": "^4.3 || ^5.0",
         "symfony/process": "^4.3 || ^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
-        "laravel/browser-kit-testing": "~5.0 || ~6.0 || ~7.0",
+        "laravel/browser-kit-testing": "~6.0 || ~7.0",
         "laravel/dusk": "~5.0 || ~6.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
+        "orchestra/testbench": "^5.0 || ^6.0",
         "phpunit/phpunit": "8.* || 9.*",
         "psalm/plugin-laravel": "^1.4",
         "rector/rector": "^0.11.58",


### PR DESCRIPTION
This PR drops support for Laravel 6 which will stop receiving bug fixes in January 2022. ([Laravel's support policy](https://laravel.com/docs/8.x/releases#support-policy)).

laravel-stats can still be installed in Laravel 6 projects. It will just not receive any new features that might be coming in the future.
This will make adding support for PHP 8.1 easier, as the builds for Larvel 6 on PHP 8.1 are failing (see #198)



