### PR TITLE
Fix Issue with Anonymous Database Migrations

### DIFF
--- a/src/Console/StatsListCommand.php
+++ b/src/Console/StatsListCommand.php
@@ -49,7 +49,14 @@ class StatsListCommand extends Command
         })->reject(function (ReflectionClass $class) {
             return app(config('stats.rejection_strategy', RejectVendorClasses::class))
                 ->shouldClassBeRejected($class);
+        })->unique(function (ReflectionClass  $class) {
+            return $class->getFileName();
         })->reject(function (ReflectionClass $class) {
+            // Never discard anonymous database migrations
+            if (Str::contains($class->getName(), 'Migration@anonymous')) {
+                return false;
+            }
+
             foreach (config('stats.ignored_namespaces', []) as $namespace) {
                 if (Str::startsWith($class->getNamespaceName(), $namespace)) {
                     return true;

--- a/tests/ClassesFinderTest.php
+++ b/tests/ClassesFinderTest.php
@@ -81,7 +81,7 @@ class ClassesFinderTest extends TestCase
     /** @test */
     public function it_finds_migrations()
     {
-        $this->assertTrue($this->classes->contains(\Wnx\LaravelStats\Tests\Stubs\Migrations\CreateUsersTable::class));
+        $this->assertTrue($this->classes->contains(\Wnx\LaravelStats\Tests\Stubs\Migrations\CreatePasswordResetsTable::class));
     }
 
     /** @test */

--- a/tests/Classifiers/MigrationClassifierTest.php
+++ b/tests/Classifiers/MigrationClassifierTest.php
@@ -2,21 +2,35 @@
 
 namespace Wnx\LaravelStats\Tests\Classifiers;
 
+use Wnx\LaravelStats\Tests\Stubs\Migrations\CreatePasswordResetsTable;
 use Wnx\LaravelStats\Tests\TestCase;
 use Wnx\LaravelStats\ReflectionClass;
 use Wnx\LaravelStats\Classifiers\MigrationClassifier;
-use Wnx\LaravelStats\Tests\Stubs\Migrations\CreateUsersTable;
 
 class MigrationClassifierTest extends TestCase
 {
     /** @test */
     public function it_returns_true_if_given_class_is_a_migration()
     {
-        require_once __DIR__.'/../Stubs/Migrations/2014_10_12_000000_create_users_table.php';
+        require_once __DIR__.'/../Stubs/Migrations/2014_10_12_100000_create_password_resets_table.php';
 
         $this->assertTrue(
             (new MigrationClassifier())->satisfies(
-                new ReflectionClass(CreateUsersTable::class)
+                new ReflectionClass(CreatePasswordResetsTable::class)
+            )
+        );
+    }
+
+    /** @test */
+    public function it_detects_anonymous_migrations()
+    {
+        $createUsersTableMigration = require __DIR__.'/../Stubs/Migrations/2014_10_12_000000_create_users_table.php';
+
+        $reflectionClass = new ReflectionClass($createUsersTableMigration);
+
+        $this->assertTrue(
+            (new MigrationClassifier())->satisfies(
+                $reflectionClass
             )
         );
     }

--- a/tests/Console/StatsListCommandTest.php
+++ b/tests/Console/StatsListCommandTest.php
@@ -105,6 +105,13 @@ class StatsListCommandTest extends TestCase
         $this->assertStringContainsString('StatsListCommandTest', $output);
 
         $this->assertJson($output);
+
+        $outputAsCollection = collect(json_decode($output, true));
+        $components = collect($outputAsCollection->get('components'));
+
+        $migrations = $components->firstWhere('name', 'Migrations');
+
+        $this->assertEquals(2, $migrations['number_of_classes']);
     }
 
     /** @test */

--- a/tests/Stubs/Migrations/2014_10_12_000000_create_users_table.php
+++ b/tests/Stubs/Migrations/2014_10_12_000000_create_users_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateUsersTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -16,9 +16,10 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->increments('id');
+            $table->id();
             $table->string('name');
             $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
@@ -34,4 +35,5 @@ class CreateUsersTable extends Migration
     {
         Schema::dropIfExists('users');
     }
-}
+};
+


### PR DESCRIPTION
Stats ignores classes inside the `Illuminate`-namespace by default to not pollute the result with classes that ship with the framework.
This also includes [anonymous migrations](https://laravel.com/docs/master/migrations#anonymous-migrations). These migrations are located under the `Illuminate\Database\Migrations\Migration` namespace.

Therefore, if you've upgrade your app with Laravel Shift and your migrations have been updated to the anonymous syntax, stats didn't count these classes in the statistics anymore.

This PR fixes this issue by never discarding classes that have `Migration@anonymous` in their name.