### PR TITLE
Ignore Pest Files when finding and loading Classes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         php: [8.0, 8.1, 8.2]
         laravel: [9.*, 10.*]
         phpunit: [9.*, 10.*]
-        dependency-version: [prefer-lowest, prefer-stable]
+        stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
@@ -24,17 +24,11 @@ jobs:
           - laravel: 9.*
             phpunit: 10.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} PU${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} PU${{ matrix.phpunit }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -47,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ composer.lock
 build
 vendor
 .phpunit.result.cache
+.phpunit.cache
 .php_cs.cache
 .php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The verbose option is available for the JSON format also.
 php artisan stats --json --verbose
 ```
 
+> **Note**
+> If your project is using [Pest PHP](https://pestphp.com) for writing tests, these files will automatically be excluded from the statistics. Due to how "laravel-stats" works internally, Pest PHP tests can't currently be detected. See [#194](https://github.com/stefanzweifel/laravel-stats/discussions/194) for more information.
 
 ## How does this package detect certain Laravel Components?
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "laravel/dusk": "^6.0|^7.0",
         "livewire/livewire": "^2.0",
         "orchestra/testbench": "^7.0 | ^8.0",
+        "pestphp/pest": "^2",
         "phpunit/phpunit": "^9.0 | ^10.0",
         "rector/rector": "^0.15",
         "vimeo/psalm": "^5.0"
@@ -48,7 +49,10 @@
         "test": "vendor/bin/phpunit"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "laravel/dusk": "^6.0|^7.0",
         "livewire/livewire": "^2.0",
         "orchestra/testbench": "^7.0 | ^8.0",
-        "pestphp/pest": "^2",
+        "pestphp/pest": "^1 || ^2",
         "phpunit/phpunit": "^9.0 | ^10.0",
         "rector/rector": "^0.15",
         "vimeo/psalm": "^5.0"

--- a/src/ClassesFinder.php
+++ b/src/ClassesFinder.php
@@ -22,8 +22,13 @@ class ClassesFinder
         $this->findFilesInProjectPath()
             ->each(function (SplFileInfo $file) {
                 try {
+                    // Files that look like to be Pest Tests are ignored as we currently don't support them.
+                    if ($this->isMostLikelyPestTest($file)) {
+                         return true;
+                    }
                     require_once $file->getRealPath();
                 } catch (Exception $e) {
+                    //
                 }
             });
 
@@ -54,13 +59,49 @@ class ClassesFinder
 
     /**
      * Determine if a file has been defined in the exclude configuration.
-     *
-     *
      */
     protected function isExcluded(SplFileInfo $file, Collection $excludes): bool
     {
         return $excludes->contains(function ($exclude) use ($file) {
             return Str::startsWith($file->getPathname(), $exclude);
         });
+    }
+
+    /**
+     * Determine if a file is a Pest Test.
+     * Pest Tess are currently not supported as requiring them will throw an exception.
+     */
+    protected function isMostLikelyPestTest(SplFileInfo $file): bool
+    {
+        // If the file path does not contain "test" or "Test", then it's probably not a Pest Test.
+        if (! str_contains($file->getRealPath(), 'test') && ! str_contains($file->getRealPath(), 'Test')) {
+            return false;
+        }
+
+        $fileContent = file_get_contents($file->getRealPath());
+
+        // Check if file contains "class $name" syntax.
+        // If it does, it's probably a normal PhpUnit Test.
+        if (preg_match('/class\s/', $fileContent)) {
+            return false;
+        }
+
+        // Check if file contains method calls to prominent Pest functions.
+        // If it does, it's probably a Pest Test.
+        $methodNames = implode('|', [
+            'describe',
+            'test',
+            'it',
+            'beforeEach',
+            'afterEach',
+            'beforeAll',
+            'afterAll',
+        ]);
+
+        if (preg_match("/$methodNames\s*\(/", $fileContent)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/ClassesFinder.php
+++ b/src/ClassesFinder.php
@@ -24,7 +24,7 @@ class ClassesFinder
                 try {
                     // Files that look like to be Pest Tests are ignored as we currently don't support them.
                     if ($this->isMostLikelyPestTest($file)) {
-                         return true;
+                        return true;
                     }
                     require_once $file->getRealPath();
                 } catch (Exception $e) {

--- a/src/ClassesFinder.php
+++ b/src/ClassesFinder.php
@@ -73,6 +73,10 @@ class ClassesFinder
      */
     protected function isMostLikelyPestTest(SplFileInfo $file): bool
     {
+        if (str_ends_with($file->getRealPath(), 'Pest.php')) {
+            return true;
+        }
+
         // If the file path does not contain "test" or "Test", then it's probably not a Pest Test.
         if (! str_contains($file->getRealPath(), 'test') && ! str_contains($file->getRealPath(), 'Test')) {
             return false;

--- a/stubs/Pest.php
+++ b/stubs/Pest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;

--- a/stubs/Pest.php
+++ b/stubs/Pest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+uses(TestCase::class, RefreshDatabase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}
+
+function getFixture($path)
+{
+    return File::get(base_path("tests/fixtures/{$path}"));
+}

--- a/stubs/PestTest.php
+++ b/stubs/PestTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 test('that true is true', function () {
     expect(true)->toBeTrue();

--- a/stubs/PestTest.php
+++ b/stubs/PestTest.php
@@ -1,0 +1,9 @@
+<?php
+
+test('that true is true', function () {
+    expect(true)->toBeTrue();
+});
+
+it('asserts that true is true', function () {
+    expect(true)->toBeTrue();
+});

--- a/stubs/README.md
+++ b/stubs/README.md
@@ -1,0 +1,3 @@
+# Not autoloaded Stubs
+
+This directory contains stubs that are not autoloaded by composer.

--- a/tests/ClassesFinderTest.php
+++ b/tests/ClassesFinderTest.php
@@ -27,6 +27,7 @@ class ClassesFinderTest extends TestCase
         config()->set('stats', [
             'paths' => [
                 __DIR__.'/../tests/Stubs',
+                __DIR__.'/../stubs/',
             ],
             'exclude' => $excludedFiles,
             'ignored_namespaces' => [],


### PR DESCRIPTION
This PR is an attempt to solve compatibility issues when the laravel-stats package is run in a project that uses [PestPHP](https://pestphp.com).

Due to the nature of how laravel-stats currently works, we can't easily provide support for Pest Tests. (`stats` searches for PHP **Classes** in your project and groups them into Components. Pest Tests are PHP files containing functions.)

This PR attempts to solve the compatibility issue, by checking the contents of a PHP file, before requiring it.
If the file contains "test" or "Test" and uses one of the prominent Pest PHP methods like `test()`, `it()`, `describe()` or `beforeEach()`, we consider it a Pest PHP file and exclude it from being required.
(Might be a too naive approach, but I can't think of anything better right now.)

## More Technical Notes
When users run `php artisan stats` in a project that uses Pest, they are immediately greeted with the following error message.

```shell
Pest\Exceptions\InvalidPestCommand

Please run [./vendor/bin/pest] instead.
```

This happens as `stats` immediately starts looking for files in a project and requiring them in the [`ClassesFinder`-class](https://github.com/stefanzweifel/laravel-stats/blob/695d87eaf8da5d01cac833092feae82300157d4a/src/ClassesFinder.php#L25).
When a Pest file is required, the `test()` or `it()` method seems to be immediately triggered or executed, which in turn will execute the following line in Pest that runs `TestSuite::getInstance()`.

https://github.com/pestphp/pest/blob/f1414a0beb43da066cf33276e22ea1209f047667/src/Functions.php#L121

As Pest is not triggered in a test environment the InvalidPestCommand exception is [thrown](https://github.com/pestphp/pest/blob/2.x/src/TestSuite.php#L103-L105).

## Related Issues
- #194 
- #218 

## TODOs

- [x] Add Note about Pest PHP compatibility to README